### PR TITLE
Add a way to tell what role repmgr thinks we are

### DIFF
--- a/pkg/flypg/repmgr.go
+++ b/pkg/flypg/repmgr.go
@@ -1,7 +1,9 @@
 package flypg
 
 import (
+	"context"
 	"fmt"
+	"github.com/jackc/pgx/v4"
 	"os"
 )
 
@@ -133,4 +135,17 @@ func writePasswdConf(node Node) error {
 	}
 
 	return nil
+}
+
+func (n *Node) currentRole(ctx context.Context, pg *pgx.Conn) (string, error) {
+	sql := fmt.Sprintf("select n.type from repmgr.nodes n LEFT JOIN repmgr.nodes un ON un.node_id = n.upstream_node_id WHERE n.node_id = '%d';", n.ID)
+	var role string
+	err := pg.QueryRow(ctx, sql).Scan(&role)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return "", nil
+		}
+		return "", err
+	}
+	return role, nil
 }


### PR DESCRIPTION
I stole this sql from repmgrs internals https://github.com/EnterpriseDB/repmgr/blob/3b897318998114ba2760057c9a18bc7601771ca3/dbutils.c#L2773.

I need a some sort of chaos monkey script to test this kind of code.