### PR TITLE
Don't re-clone Standbys on every reboot

### DIFF
--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -144,8 +144,7 @@ func (n *Node) Init() error {
 				return fmt.Errorf("failed to resolve role for %s: %s", primaryIP, err)
 			}
 
-			fmt.Printf("My Role is: %s\n", role)
-			// Don't re-clone if we are already a standby.
+			fmt.Printf("My role is: %s\n", role)
 			if role == standbyRoleName {
 				clonePrimary = false
 			}
@@ -193,7 +192,12 @@ func (n *Node) PostInit() error {
 
 	switch primaryIP {
 	case n.PrivateIP:
-		// Noop
+		// Re-register the primary in order to pick up any changes made to the
+		// configuration file.
+		fmt.Println("Updating primary record")
+		if err := registerPrimary(*n); err != nil {
+			fmt.Printf("failed to register primary: %s", err)
+		}
 	case "":
 		// Check if we can be a primary
 		if !n.validPrimary() {

--- a/pkg/flypg/repmgr.go
+++ b/pkg/flypg/repmgr.go
@@ -33,7 +33,7 @@ func initializeRepmgr(node Node) error {
 }
 
 func registerPrimary(node Node) error {
-	cmdStr := fmt.Sprintf("repmgr -f %s primary register",
+	cmdStr := fmt.Sprintf("repmgr -f %s primary register -F",
 		node.ManagerConfigPath,
 	)
 	if err := runCommand(cmdStr); err != nil {


### PR DESCRIPTION
Notables:

1. Primary/Standby registrations are now forced on reboot, this will rewrite the record within `repmgr` and seems to be required to pick up any changes made to the `repmgr.conf` file. 

2. We are only cloning from the primary if we are a new standby or if we are a recovering primary ( that's no longer primary).

cc:// @DAlperin  