### PR TITLE
Fencing a failed primary

### DIFF
--- a/pkg/flycheck/role.go
+++ b/pkg/flycheck/role.go
@@ -26,7 +26,7 @@ func PostgreSQLRole(ctx context.Context, checks *check.CheckSuite) (*check.Check
 	}
 
 	checks.AddCheck("role", func() (string, error) {
-		if node.ZombieLockExists() {
+		if flypg.ZombieLockExists() {
 			return "zombie", nil
 		}
 

--- a/pkg/flycheck/role.go
+++ b/pkg/flycheck/role.go
@@ -2,6 +2,7 @@ package flycheck
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/fly-apps/postgres-flex/pkg/flypg"
 	"github.com/pkg/errors"
@@ -27,7 +28,7 @@ func PostgreSQLRole(ctx context.Context, checks *check.CheckSuite) (*check.Check
 
 	checks.AddCheck("role", func() (string, error) {
 		if flypg.ZombieLockExists() {
-			return "zombie", nil
+			return "zombie", fmt.Errorf("member is in a zombie state. see logs for more details")
 		}
 
 		member, err := node.RepMgr.Member(ctx, conn)

--- a/pkg/flycheck/role.go
+++ b/pkg/flycheck/role.go
@@ -38,7 +38,12 @@ func PostgreSQLRole(ctx context.Context, checks *check.CheckSuite) (*check.Check
 
 		switch member.Role {
 		case flypg.PrimaryRoleName:
-			return "primary", nil
+			if member.Active {
+				return "primary", nil
+			} else {
+				return "zombie", nil
+			}
+
 		case flypg.StandbyRoleName:
 			return "replica", nil
 		default:

--- a/pkg/flycheck/role.go
+++ b/pkg/flycheck/role.go
@@ -26,6 +26,10 @@ func PostgreSQLRole(ctx context.Context, checks *check.CheckSuite) (*check.Check
 	}
 
 	checks.AddCheck("role", func() (string, error) {
+		if node.ZombieLockExists() {
+			return "zombie", nil
+		}
+
 		member, err := node.RepMgr.Member(ctx, conn)
 		if err != nil {
 			return "failed", errors.Wrap(err, "failed to check role")

--- a/pkg/flypg/admin/admin.go
+++ b/pkg/flypg/admin/admin.go
@@ -330,3 +330,45 @@ func GetSetting(ctx context.Context, pg *pgx.Conn, setting string) (*PGSetting, 
 	}
 	return &out, nil
 }
+
+func SetReadOnly(ctx context.Context, conn *pgx.Conn) error {
+	databases, err := ListDatabases(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	for _, db := range databases {
+		if db.Name == "repmgr" || db.Name == "postgres" {
+			continue
+		}
+
+		sql := fmt.Sprintf("ALTER DATABASE %s set default_transaction_read_only = true;", db.Name)
+		_, err := conn.Exec(ctx, sql)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func UnsetReadOnly(ctx context.Context, conn *pgx.Conn) error {
+	databases, err := ListDatabases(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	for _, db := range databases {
+		if db.Name == "repmgr" || db.Name == "postgres" {
+			continue
+		}
+
+		sql := fmt.Sprintf("ALTER DATABASE %s set default_transaction_read_only = false;", db.Name)
+		_, err := conn.Exec(ctx, sql)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -446,7 +446,7 @@ func (n *Node) configure(ctx context.Context, store *state.Store) error {
 		fmt.Println(err.Error())
 	}
 
-	// Reset PG Primary and wait for primary resolution
+	// Clear target and wait for primary resolution
 	if err := n.PGBouncer.ConfigurePrimary(ctx, "", false); err != nil {
 		fmt.Println(err.Error())
 	}

--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -131,7 +131,7 @@ func (n *Node) Init(ctx context.Context) error {
 		if zHostname == "" {
 			// TODO - Provide link to documention on how to address this
 			fmt.Println("Zombie lock does not contain a valid hostname!")
-			fmt.Println("This likely means that we were unable to build a consensus who the real primary is.")
+			fmt.Println("This likely means that we were unable to build a consensus on who the real primary is.")
 			fmt.Println("If you feel like this is a mistake, you can force a retry by deleting the zombie.lock file.")
 			fmt.Println("Sleeping for 2 minutes.")
 			time.Sleep(2 * time.Minute)

--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -129,7 +129,8 @@ func (n *Node) Init(ctx context.Context) error {
 		}
 
 		if zHostname == "" {
-			return fmt.Errorf("zombie lock present with no primary specified. If you think this is by mistake, remove the zombie.lock file")
+			fmt.Println("Zombie lock does not contain a valid hostname. This means that we were unable to build a consensus on who the real primary is.")
+			return fmt.Errorf("unrecoverable zombie state")
 		}
 
 		if err := n.RepMgr.rejoinCluster(zHostname); err != nil {

--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -131,8 +131,10 @@ func (n *Node) Init(ctx context.Context) error {
 		if zHostname == "" {
 			// TODO - Provide link to documention on how to address this
 			fmt.Println("Zombie lock does not contain a valid hostname!")
-			fmt.Println("This likely means that we were unable to build a consensus who the real primary is")
-			fmt.Println("If you feel like this is a mistake, force a retry by deleting the zombie.lock file")
+			fmt.Println("This likely means that we were unable to build a consensus who the real primary is.")
+			fmt.Println("If you feel like this is a mistake, you can force a retry by deleting the zombie.lock file.")
+			fmt.Println("Sleeping for 2 minutes.")
+			time.Sleep(2 * time.Minute)
 			return fmt.Errorf("unrecoverable zombie")
 		}
 

--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -173,6 +173,8 @@ func (n *Node) Init(ctx context.Context) error {
 				return fmt.Errorf("failed to rejoin cluster: %s", err)
 			}
 
+			// TODO - Wait for target cluster to register self as a standby.
+
 			if err := removeZombieLock(); err != nil {
 				return fmt.Errorf("failed to remove zombie lock: %s", err)
 			}
@@ -229,6 +231,10 @@ func (n *Node) Init(ctx context.Context) error {
 	fmt.Println("Initializing Postgres configuration")
 	if err := n.configurePostgres(store); err != nil {
 		return fmt.Errorf("failed to configure postgres: %s", err)
+	}
+
+	if err := setDirOwnership(); err != nil {
+		return err
 	}
 
 	return nil
@@ -488,6 +494,7 @@ func (n *Node) configure(ctx context.Context, store *state.Store) error {
 	}
 
 	// Clear target and wait for primary resolution
+	fmt.Println("Disabling PGBouncer until primary is resolved")
 	if err := n.PGBouncer.ConfigurePrimary(ctx, "", false); err != nil {
 		return fmt.Errorf("failed to set pgbouncer target: %s", err)
 	}

--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -324,8 +324,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 
 					fmt.Println("Identifying ourself as a Zombie")
 
-					// if primary is non-empty we were able to build a consensus on who the real primary and should
-					// be recoverable on reboot.
+					// If primary is non-empty we were able to build a consensus on who the real primary is.
 					if primary != "" {
 						fmt.Printf("Majority of members agree that %s is the real primary\n", primary)
 						fmt.Println("Reconfiguring PGBouncer to point to the real primary")
@@ -334,17 +333,17 @@ func (n *Node) PostInit(ctx context.Context) error {
 						}
 					}
 					// Create a zombie.lock file containing the resolved primary.
-					// This will be an empty string if we are unable to resolve the real primary.
+					// Note: This will be an empty string if we are unable to resolve the real primary.
 					if err := writeZombieLock(primary); err != nil {
 						return fmt.Errorf("failed to set zombie lock: %s", err)
 					}
 
-					fmt.Println("Setting all existing tables to read-only")
+					fmt.Println("User-created databases are being made readonly")
 					if err := admin.SetReadOnly(ctx, conn); err != nil {
 						return fmt.Errorf("failed to set read-only: %s", err)
 					}
 
-					return fmt.Errorf("zombie primary detected. Use `fly machines restart <machine-id>` to rejoin the cluster or consider removing this node")
+					panic("zombie primary detected.")
 				}
 
 				return fmt.Errorf("failed to run zombie diagnosis: %s", err)

--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -21,8 +21,6 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
-var ErrForceRestart = errors.New("full restart triggered")
-
 type Credentials struct {
 	Username string
 	Password string

--- a/pkg/flypg/pg.go
+++ b/pkg/flypg/pg.go
@@ -205,6 +205,7 @@ func (c *PGConfig) SetDefaults() error {
 		"max_wal_size":             fmt.Sprintf("%dMB", int(maxWalMb)),
 		"wal_compression":          "on",
 		"wal_level":                "replica",
+		"wal_log_hints":            true,
 		"hot_standby":              true,
 		"archive_mode":             true,
 		"archive_command":          "'/bin/true'",

--- a/pkg/flypg/repmgr.go
+++ b/pkg/flypg/repmgr.go
@@ -111,10 +111,6 @@ func (r *RepMgr) setup(ctx context.Context, conn *pgx.Conn) error {
 	return nil
 }
 
-// func (r *RepMgr) CurrentRole(ctx context.Context, pg *pgx.Conn) (string, error) {
-// 	return r.memberRole(ctx, pg, int(r.ID))
-// }
-
 func (r *RepMgr) setDefaults() {
 	conf := ConfigMap{
 		"node_id":                      fmt.Sprint(r.ID),
@@ -167,13 +163,15 @@ func (r *RepMgr) followPrimary() error {
 }
 
 func (r *RepMgr) rejoinCluster(hostname string) error {
-	cmdStr := fmt.Sprintf("repmgr -f %s node rejoin -h %s -p %d -U %s -d %s --force-rewind -W",
+	cmdStr := fmt.Sprintf("repmgr -f %s node rejoin -h %s -p %d -U %s -d %s --force-rewind --no-wait",
 		r.ConfigPath,
 		hostname,
 		r.Port,
 		r.Credentials.Username,
 		r.DatabaseName,
 	)
+
+	fmt.Println(cmdStr)
 
 	if err := utils.RunCommand(cmdStr); err != nil {
 		return err

--- a/pkg/flypg/zombie.go
+++ b/pkg/flypg/zombie.go
@@ -2,7 +2,6 @@ package flypg
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 )
 
@@ -15,7 +14,7 @@ func ZombieLockExists() bool {
 }
 
 func writeZombieLock(hostname string) error {
-	if err := ioutil.WriteFile("/data/zombie.lock", []byte(hostname), 0644); err != nil {
+	if err := os.WriteFile("/data/zombie.lock", []byte(hostname), 0644); err != nil {
 		return err
 	}
 
@@ -31,7 +30,7 @@ func removeZombieLock() error {
 }
 
 func readZombieLock() (string, error) {
-	body, err := ioutil.ReadFile("/data/zombie.lock")
+	body, err := os.ReadFile("/data/zombie.lock")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/flypg/zombie.go
+++ b/pkg/flypg/zombie.go
@@ -48,58 +48,36 @@ func ZombieDiagnosis(myHostname string, total int, inactive int, active int, con
 		return myHostname, nil
 	}
 
-	// Two node cluster
-	if total == 2 {
-		// We can't know if we are the true primary if our only standby is inactive or has conflicts.
-		if len(conflictMap) > 0 || inactive == 1 {
-			return "", ErrZombieDiscovered
-		}
+	quorum := total/2 + 1
 
-		return myHostname, nil
-	}
-
-	// If all standbys are inactive, then we hae to assume a possible network split.
-	if total == (inactive - 1) {
-		return "", ErrZombieDiscovered
-	}
-
-	quorum := (total/2 + 1)
-
-	// if we have enough active nodes to meet quorum and there are no conflicts we are the primary.
-	if len(conflictMap) == 0 && active >= quorum {
-		return myHostname, nil
-	}
-
+	// Active members must at least equal quorum in order for primary resolution to be succcessful.
 	if active < quorum {
 		return "", ErrZombieDiscovered
 	}
 
 	topCandidate := ""
-	highestCount := 0
+	highestTotal := 0
 	totalConflicts := 0
 
 	// Evaluate conflicts to calculate the highest referrenced primary
 	for hostname, total := range conflictMap {
 		totalConflicts += total
 
-		if total > highestCount {
-			highestCount = total
+		if total > highestTotal {
+			highestTotal = total
 			topCandidate = hostname
 		}
 	}
 
-	// Calculate our count
 	myCount := total - inactive - totalConflicts
 
-	// If we meet quorum, we are done here.
 	if myCount >= quorum {
 		return myHostname, nil
 	}
 
-	// If our highest
-	if highestCount < quorum {
-		return "", ErrZombieDiscovered
+	if highestTotal >= quorum {
+		return topCandidate, ErrZombieDiscovered
 	}
 
-	return topCandidate, ErrZombieDiscovered
+	return "", ErrZombieDiscovered
 }

--- a/pkg/flypg/zombie.go
+++ b/pkg/flypg/zombie.go
@@ -42,7 +42,7 @@ func readZombieLock() (string, error) {
 
 var ErrZombieDiscovered = errors.New("Zombie")
 
-func ZombieEval(myHostname string, total int, inactive int, active int, conflictMap map[string]int) (string, error) {
+func ZombieDiagnosis(myHostname string, total int, inactive int, active int, conflictMap map[string]int) (string, error) {
 	// No standbys
 	if total == 1 {
 		return myHostname, nil

--- a/pkg/flypg/zombie.go
+++ b/pkg/flypg/zombie.go
@@ -43,14 +43,14 @@ var ErrZombieDiscovered = errors.New("Zombie")
 
 // ZombieDiagnosis takes information about the current cluster state and determines whether it is safe to boot ourself as the primary.
 func ZombieDiagnosis(myHostname string, total int, inactive int, active int, conflictMap map[string]int) (string, error) {
-	// Single node cluster
+	// We can short-circuit a single node cluster.
 	if total == 1 {
 		return myHostname, nil
 	}
 
 	quorum := total/2 + 1
 
-	// Active members must at least equal quorum in order for primary resolution to be succcessful.
+	// Active members must meet quorum.
 	if active < quorum {
 		return "", ErrZombieDiscovered
 	}
@@ -59,7 +59,7 @@ func ZombieDiagnosis(myHostname string, total int, inactive int, active int, con
 	highestTotal := 0
 	totalConflicts := 0
 
-	// Evaluate conflicts to calculate the highest referrenced primary
+	// Evaluate conflicts and calculate top referenced primary
 	for hostname, total := range conflictMap {
 		totalConflicts += total
 
@@ -69,6 +69,7 @@ func ZombieDiagnosis(myHostname string, total int, inactive int, active int, con
 		}
 	}
 
+	// Calculate our references
 	myCount := total - inactive - totalConflicts
 
 	if myCount >= quorum {

--- a/pkg/flypg/zombie.go
+++ b/pkg/flypg/zombie.go
@@ -42,64 +42,73 @@ func readZombieLock() (string, error) {
 
 var ErrZombieDiscovered = errors.New("Zombie")
 
+// ZombieDiagnosis takes information about the current cluster state and does two things.
+// 1. Determines whether or not we are a primary coming back from the dead.
+// 2. If we are indeed a zombie, we want to see if we can resolve who the real primary is.
 func ZombieDiagnosis(myHostname string, total int, inactive int, active int, conflictMap map[string]int) (string, error) {
-	// No standbys
+	// Single node cluster
 	if total == 1 {
 		return myHostname, nil
 	}
 
-	// If all standbys are inactive
-	if total == (inactive - 1) {
-		// Possible network split
-		return "", ErrZombieDiscovered
-	}
-
+	// Two node setup
 	if total == 2 {
-		if len(conflictMap) > 0 || inactive > 0 {
+		// If the one standby is inactive we can will not be able to determine a down node from a net-split.
+		// If the standby reports a different primary we have diverged greatly.
+		if len(conflictMap) > 0 || inactive == 1 {
 			return "", ErrZombieDiscovered
 		}
 
 		return myHostname, nil
 	}
 
-	// Quorum can be met so long the majority of the registered members agree on who's the primary.
+	// If all standbys are inactive, then there's a possible network split.
+	if total == (inactive - 1) {
+		return "", ErrZombieDiscovered
+	}
+
 	quorum := ((total)/2 + 1)
+
+	// If there's not enough active nodes to meet quorum we have to assume
+	// we are a zombie.
 	if active < quorum {
 		fmt.Printf("Active: %d, Quorum: %d\n", active, quorum)
 		return "", ErrZombieDiscovered
 	}
 
-	// If we can meet quorum and there's no conflicts, we can boot as primary.
+	// We can safely say we are primary if we have enough active nodes
+	// to meet quorum and there are no conflicts.
 	if len(conflictMap) == 0 && active >= quorum {
 		return myHostname, nil
 	}
 
-	highMember := ""
-	highCount := 0
+	topCandidate := ""
+	highestCount := 0
 
 	totalConflicts := 0
 
+	// Calculate total conflicts + highest reported primary
 	for hostname, total := range conflictMap {
 		totalConflicts += total
 
-		if total > highCount {
-			highCount = total
-			highMember = hostname
+		if total > highestCount {
+			highestCount = total
+			topCandidate = hostname
 		}
 	}
 
+	// We can infer our count by subtracting inactive members and total conficts.
 	myCount := total - inactive - totalConflicts
 
-	if myCount > highCount {
-		highCount = myCount
-		highMember = myHostname
+	if myCount > highestCount {
+		highestCount = myCount
+		topCandidate = myHostname
 	}
 
-	fmt.Printf("Hcount: %d, Quorum: %d\n", highCount, quorum)
-	if highCount < quorum {
+	if highestCount < quorum {
 		// Unable to reach quorum
 		return "", ErrZombieDiscovered
 	}
 
-	return highMember, nil
+	return topCandidate, nil
 }

--- a/pkg/flypg/zombie.go
+++ b/pkg/flypg/zombie.go
@@ -87,7 +87,7 @@ func ZombieDiagnosis(myHostname string, total int, inactive int, active int, con
 
 	totalConflicts := 0
 
-	// Calculate total conflicts + highest reported primary
+	// Calculate total conflicts + hgh reported primary
 	for hostname, total := range conflictMap {
 		totalConflicts += total
 

--- a/pkg/flypg/zombie.go
+++ b/pkg/flypg/zombie.go
@@ -41,9 +41,9 @@ func readZombieLock() (string, error) {
 
 var ErrZombieDiscovered = errors.New("Zombie")
 
-// ZombieDiagnosis takes information about the current cluster state and does two things:
-//  1. Determines whether or not it's safe to boot ourself as the primary.
-//  2. Try and build a consensus around who the real primary is.
+// ZombieDiagnosis takes information about the current cluster state and determines two things:
+//  1. Is it safe to boot ourself as the primary.
+//  2. Can we build a consensus on who the real primary is.
 func ZombieDiagnosis(myHostname string, total int, inactive int, active int, conflictMap map[string]int) (string, error) {
 	// Single node cluster
 	if total == 1 {
@@ -64,7 +64,7 @@ func ZombieDiagnosis(myHostname string, total int, inactive int, active int, con
 		return "", ErrZombieDiscovered
 	}
 
-	quorum := ((total)/2 + 1)
+	quorum := (total/2 + 1)
 
 	// if we have enough active nodes to meet quorum and there are no conflicts
 	// we can assume we are the primary.
@@ -81,7 +81,6 @@ func ZombieDiagnosis(myHostname string, total int, inactive int, active int, con
 	highestCount := 0
 	totalConflicts := 0
 
-	// Calculate total conflicts + hightest reported primary
 	for hostname, total := range conflictMap {
 		totalConflicts += total
 

--- a/pkg/flypg/zombie.go
+++ b/pkg/flypg/zombie.go
@@ -1,0 +1,105 @@
+package flypg
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+func ZombieLockExists() bool {
+	_, err := os.Stat("/data/zombie.lock")
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func writeZombieLock(hostname string) error {
+	if err := ioutil.WriteFile("/data/zombie.lock", []byte(hostname), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func removeZombieLock() error {
+	if err := os.Remove("/data/zombie.lock"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func readZombieLock() (string, error) {
+	body, err := ioutil.ReadFile("/data/zombie.lock")
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+var ErrZombieDiscovered = errors.New("Zombie")
+
+func ZombieEval(myHostname string, total int, inactive int, active int, conflictMap map[string]int) (string, error) {
+	// No standbys
+	if total == 1 {
+		return myHostname, nil
+	}
+
+	// If all standbys are inactive
+	if total == (inactive - 1) {
+		// Possible network split
+		return "", ErrZombieDiscovered
+	}
+
+	if total == 2 {
+		if len(conflictMap) > 0 || inactive > 0 {
+			return "", ErrZombieDiscovered
+		}
+
+		return myHostname, nil
+	}
+
+	// Quorum can be met so long the majority of the registered members agree on who's the primary.
+	quorum := ((total)/2 + 1)
+	if active < quorum {
+		fmt.Printf("Active: %d, Quorum: %d\n", active, quorum)
+		return "", ErrZombieDiscovered
+	}
+
+	// If we can meet quorum and there's no conflicts, we can boot as primary.
+	if len(conflictMap) == 0 && active >= quorum {
+		return myHostname, nil
+	}
+
+	highMember := ""
+	highCount := 0
+
+	totalConflicts := 0
+
+	for hostname, total := range conflictMap {
+		totalConflicts += total
+
+		if total > highCount {
+			highCount = total
+			highMember = hostname
+		}
+	}
+
+	myCount := total - inactive - totalConflicts
+
+	if myCount > highCount {
+		highCount = myCount
+		highMember = myHostname
+	}
+
+	fmt.Printf("Hcount: %d, Quorum: %d\n", highCount, quorum)
+	if highCount < quorum {
+		// Unable to reach quorum
+		return "", ErrZombieDiscovered
+	}
+
+	return highMember, nil
+}

--- a/pkg/flypg/zombie.go
+++ b/pkg/flypg/zombie.go
@@ -79,7 +79,11 @@ func ZombieDiagnosis(myHostname string, total int, inactive int, active int, con
 	// Calculate our references
 	myCount := total - inactive - totalConflicts
 
+	// We have to fence the primary in case the active cluster is in the middle of a failover.
 	if myCount >= quorum {
+		if totalConflicts > 0 {
+			return "", ErrZombieDiagnosisUndecided
+		}
 		return myHostname, nil
 	}
 

--- a/pkg/flypg/zombie_test.go
+++ b/pkg/flypg/zombie_test.go
@@ -1,0 +1,146 @@
+package flypg
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestZombieEval(t *testing.T) {
+
+	type TestCase struct {
+		MyHostname   string
+		totalMembers int
+		// Total active members. This will never be less than 1.
+		TotalActive int
+		// Total inactive members, will never include self.
+		TotalInactive int
+		// Conflict map includes a list of primaries that differ from self
+		// and the number of occurrences found.
+		ConflictMap map[string]int
+
+		ExpectedHostname string
+	}
+
+	type TestCases struct {
+		Cases []TestCase
+	}
+
+	tests := TestCases{
+		Cases: []TestCase{
+			// Single node setup ( Only possible setup )
+			{
+				MyHostname:       "current-primary",
+				totalMembers:     1,
+				TotalActive:      1,
+				TotalInactive:    0,
+				ConflictMap:      map[string]int{},
+				ExpectedHostname: "current-primary",
+			},
+			// 2 member setup
+			{
+				MyHostname:       "current-primary",
+				totalMembers:     2,
+				TotalActive:      2,
+				TotalInactive:    0,
+				ConflictMap:      map[string]int{},
+				ExpectedHostname: "current-primary",
+			},
+			// 2 member setup with an inactive standby
+			{
+				MyHostname:       "current-primary",
+				totalMembers:     2,
+				TotalActive:      1,
+				TotalInactive:    1,
+				ConflictMap:      map[string]int{},
+				ExpectedHostname: "zombie",
+			},
+			// 2 member setup with the standby reporting different primary
+			{
+				MyHostname:    "current-primary",
+				totalMembers:  2,
+				TotalActive:   1,
+				TotalInactive: 1,
+				ConflictMap: map[string]int{
+					"host-1": 1,
+				},
+				ExpectedHostname: "zombie",
+			},
+			// 3 member setup with 1 standby offline
+			{
+				MyHostname:       "current-primary",
+				totalMembers:     3,
+				TotalActive:      2,
+				TotalInactive:    1,
+				ConflictMap:      map[string]int{},
+				ExpectedHostname: "current-primary",
+			},
+			// 3 member setup where both standby's are offline.
+			{
+				MyHostname:       "current-primary",
+				totalMembers:     3,
+				TotalActive:      1,
+				TotalInactive:    2,
+				ConflictMap:      map[string]int{},
+				ExpectedHostname: "zombie",
+			},
+			// 3 member setup where both standbys agree that i'm not the primary.
+			{
+				MyHostname:    "current-primary",
+				totalMembers:  3,
+				TotalActive:   3,
+				TotalInactive: 0,
+				ConflictMap: map[string]int{
+					"secret-primary": 2,
+				},
+				ExpectedHostname: "secret-primary",
+			},
+			// 3 member setup where 1 standby disagrees that i'm primary.
+			{
+				MyHostname:    "current-primary",
+				totalMembers:  3,
+				TotalActive:   3,
+				TotalInactive: 0,
+				ConflictMap: map[string]int{
+					"secret-primary": 1,
+				},
+				ExpectedHostname: "current-primary",
+			},
+			// 3 member setup where both standbys report different primaries.
+			{
+				MyHostname:    "current-primary",
+				totalMembers:  3,
+				TotalActive:   3,
+				TotalInactive: 0,
+				ConflictMap: map[string]int{
+					"secret-primary":   1,
+					"secret-primary-2": 1,
+				},
+				ExpectedHostname: "zombie",
+			},
+		},
+	}
+
+	for i, c := range tests.Cases {
+
+		hostname, err := ZombieEval(c.MyHostname, c.totalMembers, c.TotalInactive, c.TotalActive, c.ConflictMap)
+		fmt.Println(hostname)
+		if err != nil {
+			if errors.Is(err, ErrZombieDiscovered) {
+				if c.ExpectedHostname != "zombie" {
+					t.Logf("test case %d failed: %+v . Result: zombie", i, c)
+					t.Fail()
+					return
+				}
+			}
+		} else {
+			if c.ExpectedHostname != hostname {
+				t.Logf("test case %d expected zombie, wasn't: %+v . Result: %s", i, c, hostname)
+				t.Fail()
+			}
+
+		}
+
+	}
+
+}

--- a/pkg/flypg/zombie_test.go
+++ b/pkg/flypg/zombie_test.go
@@ -49,7 +49,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		active := 1
 
 		primary, err := ZombieDiagnosis(hostname, total, inactive, active, map[string]int{})
-		if !errors.Is(err, ErrZombieDiscovered) {
+		if !errors.Is(err, ErrZombieDiagnosisUndecided) {
 			t.Fatal(err)
 		}
 
@@ -68,7 +68,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 
 		primary, err := ZombieDiagnosis(hostname, total, inactive, active, conflictMap)
-		if !errors.Is(err, ErrZombieDiscovered) {
+		if !errors.Is(err, ErrZombieDiagnosisUndecided) {
 			t.Fatal(err)
 		}
 
@@ -119,7 +119,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		conflictMap := map[string]int{}
 
 		primary, err := ZombieDiagnosis(hostname, total, inactive, active, conflictMap)
-		if !errors.Is(err, ErrZombieDiscovered) {
+		if !errors.Is(err, ErrZombieDiagnosisUndecided) {
 			t.Fatal(err)
 		}
 
@@ -177,7 +177,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 
 		primary, err := ZombieDiagnosis(hostname, total, inactive, active, conflictMap)
-		if !errors.Is(err, ErrZombieDiscovered) {
+		if !errors.Is(err, ErrZombieDiagnosisUndecided) {
 			t.Fatal(err)
 		}
 
@@ -230,7 +230,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		conflictMap := map[string]int{}
 
 		primary, err := ZombieDiagnosis(hostname, total, inactive, active, conflictMap)
-		if !errors.Is(err, ErrZombieDiscovered) {
+		if !errors.Is(err, ErrZombieDiagnosisUndecided) {
 			t.Fatal(err)
 		}
 
@@ -250,7 +250,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 
 		primary, err := ZombieDiagnosis(hostname, total, inactive, active, conflictMap)
-		if !errors.Is(err, ErrZombieDiscovered) {
+		if !errors.Is(err, ErrZombieDiagnosisUndecided) {
 			t.Fatal(err)
 		}
 

--- a/pkg/flypg/zombie_test.go
+++ b/pkg/flypg/zombie_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestZombieEval(t *testing.T) {
+func TestZombieDiagnosis(t *testing.T) {
 
 	type TestCase struct {
 		MyHostname string

--- a/pkg/flypg/zombie_test.go
+++ b/pkg/flypg/zombie_test.go
@@ -157,11 +157,11 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 
 		primary, err := ZombieDiagnosis(hostname, total, inactive, active, conflictMap)
-		if err != nil {
+		if !errors.Is(err, ErrZombieDiagnosisUndecided) {
 			t.Fatal(err)
 		}
 
-		if primary != hostname {
+		if primary != "" {
 			t.Fatalf("expected %s, got %q", hostname, primary)
 		}
 	})

--- a/pkg/flypg/zombie_test.go
+++ b/pkg/flypg/zombie_test.go
@@ -53,7 +53,7 @@ func TestZombieEval(t *testing.T) {
 				TotalActive:      1,
 				TotalInactive:    1,
 				ConflictMap:      map[string]int{},
-				ExpectedHostname: "zombie",
+				ExpectedHostname: "",
 			},
 			// 2 member setup with the standby reporting different primary
 			{
@@ -64,7 +64,7 @@ func TestZombieEval(t *testing.T) {
 				ConflictMap: map[string]int{
 					"host-1": 1,
 				},
-				ExpectedHostname: "zombie",
+				ExpectedHostname: "",
 			},
 			// 3 member setup with 1 standby offline
 			{
@@ -82,7 +82,7 @@ func TestZombieEval(t *testing.T) {
 				TotalActive:      1,
 				TotalInactive:    2,
 				ConflictMap:      map[string]int{},
-				ExpectedHostname: "zombie",
+				ExpectedHostname: "",
 			},
 			// 3 member setup where both standbys agree that i'm not the primary.
 			{
@@ -116,7 +116,7 @@ func TestZombieEval(t *testing.T) {
 					"secret-primary":   1,
 					"secret-primary-2": 1,
 				},
-				ExpectedHostname: "zombie",
+				ExpectedHostname: "",
 			},
 		},
 	}
@@ -127,8 +127,8 @@ func TestZombieEval(t *testing.T) {
 		fmt.Println(hostname)
 		if err != nil {
 			if errors.Is(err, ErrZombieDiscovered) {
-				if c.ExpectedHostname != "zombie" {
-					t.Logf("test case %d failed: %+v . Result: zombie", i, c)
+				if c.ExpectedHostname != hostname {
+					t.Logf("test case %d failed: %+v . Result: %s", i, c, hostname)
 					t.Fail()
 					return
 				}

--- a/pkg/flypg/zombie_test.go
+++ b/pkg/flypg/zombie_test.go
@@ -123,7 +123,7 @@ func TestZombieEval(t *testing.T) {
 
 	for i, c := range tests.Cases {
 
-		hostname, err := ZombieEval(c.MyHostname, c.totalMembers, c.TotalInactive, c.TotalActive, c.ConflictMap)
+		hostname, err := ZombieDiagnosis(c.MyHostname, c.totalMembers, c.TotalInactive, c.TotalActive, c.ConflictMap)
 		fmt.Println(hostname)
 		if err != nil {
 			if errors.Is(err, ErrZombieDiscovered) {

--- a/pkg/flypg/zombie_test.go
+++ b/pkg/flypg/zombie_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestZombieDiagnosis(t *testing.T) {
 
-	t.Run("single node cluster", func(t *testing.T) {
+	t.Run("SingleMember", func(t *testing.T) {
 		hostname := "host-1"
 
 		total := 1
@@ -25,7 +25,7 @@ func TestZombieDiagnosis(t *testing.T) {
 
 	})
 
-	t.Run("two node cluster", func(t *testing.T) {
+	t.Run("TwoMember", func(t *testing.T) {
 		hostname := "host-1"
 		total := 2
 		inactive := 0
@@ -42,7 +42,7 @@ func TestZombieDiagnosis(t *testing.T) {
 
 	})
 
-	t.Run("two node cluster with inactive standby", func(t *testing.T) {
+	t.Run("TwoMemberWithInactiveStandby", func(t *testing.T) {
 		hostname := "host-1"
 		total := 2
 		inactive := 1
@@ -58,7 +58,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("two node cluster with diverged primary", func(t *testing.T) {
+	t.Run("TwoNodeWithDivergedPrimary", func(t *testing.T) {
 		hostname := "host-1"
 		total := 2
 		inactive := 1
@@ -77,7 +77,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("three node cluster", func(t *testing.T) {
+	t.Run("ThreeMember", func(t *testing.T) {
 		hostname := "host-1"
 		total := 3
 		inactive := 0
@@ -94,7 +94,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("three node cluster with one offline standby", func(t *testing.T) {
+	t.Run("ThreeMemberWithOneOfflineStandby", func(t *testing.T) {
 		hostname := "host-1"
 		total := 3
 		inactive := 1
@@ -111,7 +111,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("three node cluster with both standbys offline", func(t *testing.T) {
+	t.Run("ThreeMemberWithTwoOfflineStandby", func(t *testing.T) {
 		hostname := "host-1"
 		total := 3
 		inactive := 2
@@ -128,7 +128,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("three node cluster with real primary resolved", func(t *testing.T) {
+	t.Run("ThreeMemberWithStandbyReportDiffPrimary", func(t *testing.T) {
 		hostname := "host-1"
 		total := 3
 		inactive := 0
@@ -147,7 +147,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("three node cluster with one standby in disagreement", func(t *testing.T) {
+	t.Run("ThreeMemberWithOneStandbyInDisagreement", func(t *testing.T) {
 		hostname := "host-1"
 		total := 3
 		inactive := 0
@@ -166,7 +166,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("three node cluster with two standbys reporting different primarys", func(t *testing.T) {
+	t.Run("ThreeMemberWithTwoReportingDifferentPrimaries", func(t *testing.T) {
 		hostname := "host-1"
 		total := 3
 		inactive := 0
@@ -186,7 +186,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("four node setup", func(t *testing.T) {
+	t.Run("FourMember", func(t *testing.T) {
 		hostname := "host-1"
 
 		total := 4
@@ -204,7 +204,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("four node setup with one standby inactive", func(t *testing.T) {
+	t.Run("FourMemberWithOneStandbyInactive", func(t *testing.T) {
 		hostname := "host-1"
 
 		total := 4
@@ -222,7 +222,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("four node setup with two standbys inactive", func(t *testing.T) {
+	t.Run("FourMemberWithTwoStandbyInactive", func(t *testing.T) {
 		hostname := "host-1"
 		total := 4
 		inactive := 2
@@ -239,7 +239,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("four node setup with two standbys reporting different primary", func(t *testing.T) {
+	t.Run("FourMemberWithTwoReportingDifferentPrimary", func(t *testing.T) {
 		hostname := "host-1"
 
 		total := 4
@@ -259,7 +259,7 @@ func TestZombieDiagnosis(t *testing.T) {
 		}
 	})
 
-	t.Run("four node setup with three standbys reporting different primary", func(t *testing.T) {
+	t.Run("FourMemberWithThreeStandbyReportingDiffPrimary", func(t *testing.T) {
 		hostname := "host-1"
 		expected := "host-99"
 


### PR DESCRIPTION
This PR aims to ensure that a booting primary that has diverged from the cluster is properly isolated.

Note: There's still some cleanup to do, but the core logic is there. 

## What this doesn't solve
Split-brains as a result of a network partition.  

## How do we verify the real primary?
We start out evaluating the cluster state by checking each registered standby for connectivity and asking who their primary is.

The "clusters state" is represented across a few different dimensions:

**Total members**    
Number of registered members, including the primary.

**Total active members**
Number of members that are responsive.  This includes the primary we are evaluating, so this will never be less than one.

**Total inactive members**
Number of registered members that are non-responsive. 

**Conflict map**
The conflict map is a `map[string]int` that tracks conflicting primary's queried from our standbys and the number of occurrences a given primary was referenced.

As an example, say we have a 3 member cluster and both of the standby's indicate their registered primary does not match.  This will be recorded as: 
```
map[string]int{
  "fdaa:0:2e26:a7b:8c31:bf37:488c:2": 2
}
```

The real primary is resolvable so long as the majority of members can agree on who it is.  Quorum being defined as `total_members / 2 + 1`.

**There is one exception to note here.  When self meets quorum, we will still fence ourself in the event a conflict is found.  This is to protect against a possible race condition if we are coming up during an active failover.** 

Tests can be found here: https://github.com/fly-apps/postgres-flex/pull/49/files#diff-3d71960ff7855f775cb257a74643d67d2636b354c9d485d10c2ded2426a7f362

## What if the real primary can't be resolved or doesn't match the booting primary?

In both of these instances the primary member will be fenced. 

**If the real primary is resolvable** 
The cluster will be made read-only, the PGBouncer will be reconfigured to target the "real" primary and the ip address is written to a `zombie.lock` file.  The PGBouncer reconfiguration will ensure that any connections hitting this member will be routed to the real primary in order to minimize interruptions.  Once, completed there will be panic to force a full member restart. When the member is restarted, we will read the ip address from the `zombie.lock` file and use that to attempt to rejoin the cluster we diverged from.  If we are successful, the `zombie.lock` is cleared and we will boot as a standby.    

**Note: We will not attempt to rejoin a cluster if the resolved primary resides in a region that differs from the `PRIMARY_REGION` environment variable set on self.  The `PRIMARY_REGION` will need to be updated before a rejoin will be attempted.**

**If the real primary is NOT resolvable**
The cluster will be made read-only, PGBouncer will remain disabled and a `zombie.lock` file will be created without a value.  When the member reboots, we will read the `zombie.lock` file and see that it's empty.  This indicates that we've entered a failure mode that can't be recovered automatically.  This could be an issue where previously deleted members were not properly unregistered, or the primary's state has diverged to a point where its registered members have been cycled out.   

How to address these situations will be a part of future documentation.
    
