### PR TITLE
Add support for Fly Volume Restores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/event_handler ./cmd/event_h
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/failover_validation ./cmd/failover_validation
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/standby_cleaner ./cmd/standby_cleaner
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/pg_unregister ./cmd/pg_unregister
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/api ./cmd/api
+
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start ./cmd/start
 
 COPY ./bin/* /fly/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/event_handler ./cmd/event_h
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/failover_validation ./cmd/failover_validation
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/standby_cleaner ./cmd/standby_cleaner
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/pg_unregister ./cmd/pg_unregister
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/api ./cmd/api
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start_admin_server ./cmd/api
 
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start ./cmd/start
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/event_handler ./cmd/event_h
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/failover_validation ./cmd/failover_validation
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/standby_cleaner ./cmd/standby_cleaner
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/pg_unregister ./cmd/pg_unregister
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start_admin_server ./cmd/api
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start_admin_server ./cmd/admin_server
 
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start ./cmd/start
 

--- a/cmd/admin_server/main.go
+++ b/cmd/admin_server/main.go
@@ -6,7 +6,6 @@ import (
 )
 
 func main() {
-
 	node, err := flypg.NewNode()
 	if err != nil {
 		panic(err)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/fly-apps/postgres-flex/internal/api"
+	"github.com/fly-apps/postgres-flex/internal/flypg"
+)
+
+func main() {
+
+	node, err := flypg.NewNode()
+	if err != nil {
+		panic(err)
+	}
+
+	api.StartHttpServer(node)
+
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -13,5 +13,4 @@ func main() {
 	}
 
 	api.StartHttpServer(node)
-
 }

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -54,9 +54,12 @@ func main() {
 	svisor.AddProcess("repmgrd", fmt.Sprintf("gosu postgres repmgrd -f %s --daemonize=false", node.RepMgr.ConfigPath),
 		supervisor.WithRestart(0, 5*time.Second),
 	)
-	svisor.AddProcess("standby_cleaner", "/usr/local/bin/standby_cleaner", supervisor.WithRestart(0, 5*time.Second))
-
-	svisor.AddProcess("api", "/usr/local/bin/api")
+	svisor.AddProcess("standby_cleaner", "/usr/local/bin/standby_cleaner",
+		supervisor.WithRestart(0, 5*time.Second),
+	)
+	svisor.AddProcess("admin", "/usr/local/bin/start_admin_server",
+		supervisor.WithRestart(0, 5*time.Second),
+	)
 
 	exporterEnv := map[string]string{
 		"DATA_SOURCE_URI":                     fmt.Sprintf("[%s]:%d/postgres?sslmode=disable", node.PrivateIP, node.Port),
@@ -65,8 +68,10 @@ func main() {
 		"PG_EXPORTER_EXCLUDE_DATABASE":        "template0,template1",
 		"PG_EXPORTER_AUTO_DISCOVER_DATABASES": "true",
 	}
-
-	svisor.AddProcess("exporter", "postgres_exporter", supervisor.WithEnv(exporterEnv), supervisor.WithRestart(0, 1*time.Second))
+	svisor.AddProcess("exporter", "postgres_exporter",
+		supervisor.WithEnv(exporterEnv),
+		supervisor.WithRestart(0, 1*time.Second),
+	)
 
 	svisor.StopOnSignal(syscall.SIGINT, syscall.SIGTERM)
 

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -56,6 +56,8 @@ func main() {
 	)
 	svisor.AddProcess("standby_cleaner", "/usr/local/bin/standby_cleaner", supervisor.WithRestart(0, 5*time.Second))
 
+	svisor.AddProcess("api", "/usr/local/bin/api")
+
 	exporterEnv := map[string]string{
 		"DATA_SOURCE_URI":                     fmt.Sprintf("[%s]:%d/postgres?sslmode=disable", node.PrivateIP, node.Port),
 		"DATA_SOURCE_USER":                    node.SUCredentials.Username,
@@ -67,7 +69,7 @@ func main() {
 	svisor.AddProcess("exporter", "postgres_exporter", supervisor.WithEnv(exporterEnv), supervisor.WithRestart(0, 1*time.Second))
 
 	svisor.StopOnSignal(syscall.SIGINT, syscall.SIGTERM)
-	svisor.StartHttpListener(node)
+	// svisor.StartHttpListener(node)
 
 	if err := svisor.Run(); err != nil {
 		fmt.Println(err)

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -69,7 +69,6 @@ func main() {
 	svisor.AddProcess("exporter", "postgres_exporter", supervisor.WithEnv(exporterEnv), supervisor.WithRestart(0, 1*time.Second))
 
 	svisor.StopOnSignal(syscall.SIGINT, syscall.SIGTERM)
-	// svisor.StartHttpListener(node)
 
 	if err := svisor.Run(); err != nil {
 		fmt.Println(err)

--- a/internal/flypg/node.go
+++ b/internal/flypg/node.go
@@ -123,8 +123,23 @@ func NewNode() (*Node, error) {
 }
 
 func (n *Node) Init(ctx context.Context) error {
+	// Ensure directory and files have proper permissions
 	if err := setDirOwnership(); err != nil {
 		return err
+	}
+
+	// Initiate a restore
+	if os.Getenv("FLY_RESTORED_FROM") != "" {
+		isRestore, err := isActiveRestore()
+		if err != nil {
+			return err
+		}
+
+		if isRestore {
+			if err := Restore(ctx, n); err != nil {
+				return fmt.Errorf("failed to issue restore: %s", err)
+			}
+		}
 	}
 
 	if ZombieLockExists() {

--- a/internal/flypg/node.go
+++ b/internal/flypg/node.go
@@ -130,6 +130,7 @@ func (n *Node) Init(ctx context.Context) error {
 
 	// Initiate a restore
 	if os.Getenv("FLY_RESTORED_FROM") != "" {
+		// Check to see if there's an active restore.
 		isRestore, err := isActiveRestore()
 		if err != nil {
 			return err

--- a/internal/flypg/restore.go
+++ b/internal/flypg/restore.go
@@ -85,7 +85,7 @@ func Restore(ctx context.Context, node *Node) error {
 	return nil
 }
 
-func isActiveRestore() (bool, error) {
+func isRestoreActive() (bool, error) {
 	if _, err := os.Stat(restoreLockFile); err == nil {
 		val, err := os.ReadFile(restoreLockFile)
 		if err != nil {

--- a/internal/flypg/restore.go
+++ b/internal/flypg/restore.go
@@ -20,11 +20,9 @@ const (
 func Restore(ctx context.Context, node *Node) error {
 	fmt.Println("Backing up HBA File")
 	if err := backupHBAFile(); err != nil {
-		fmt.Println(err)
+		// The HBAFile will not exist when a new standby is coming up.
 		if os.IsNotExist(err) {
-			fmt.Println("HBA FILE is not here for some reason, sleep for investigation")
-			time.Sleep(2 * time.Minute)
-			return err
+			return nil
 		}
 		return fmt.Errorf("failed backing up pg_hba.conf: %s", err)
 	}

--- a/internal/flypg/restore.go
+++ b/internal/flypg/restore.go
@@ -5,15 +5,81 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
-	"github.com/fly-apps/postgres-flex/internal/utils"
+	"github.com/fly-apps/postgres-flex/internal/supervisor"
+	"github.com/jackc/pgx/v5"
 )
 
 const (
-	pathToHBAFile   = "/data/postgres/pg_hba.conf"
-	pathToBackup    = "/data/postgres/pg_hba.conf.bak"
+	pathToHBAFile   = "/data/postgresql/pg_hba.conf"
+	pathToHBABackup = "/data/postgresql/pg_hba.conf.bak"
 	restoreLockFile = "/data/restore.lock"
 )
+
+func Restore(ctx context.Context, node *Node) error {
+	fmt.Println("Backing up HBA File")
+	if err := backupHBAFile(); err != nil {
+		fmt.Println(err)
+		if os.IsNotExist(err) {
+			fmt.Println("HBA FILE is not here for some reason, sleep for investigation")
+			time.Sleep(2 * time.Minute)
+			return err
+		}
+		return fmt.Errorf("failed backing up pg_hba.conf: %s", err)
+	}
+
+	fmt.Println("Overwriting HBA file so we can update authentication")
+	if err := overwriteHBAFile(); err != nil {
+		return fmt.Errorf("failed to overwrite pg_hba.conf: %s", err)
+	}
+
+	if _, err := os.Stat("/data/postgresql/standby.signal"); err == nil {
+		fmt.Println("restoring from a hot standby. clearing standby signal so we can boot.")
+		// We are restoring from a hot standby, so we need to clear the signal so we can boot.
+		if err = os.Remove("/data/postgresql/standby.signal"); err != nil {
+			return fmt.Errorf("failed to remove standby signal: %s", err)
+		}
+	}
+
+	fmt.Println("Starting PG in standalone mode")
+
+	svisor := supervisor.New("flypg", 5*time.Minute)
+	svisor.AddProcess("postgres", fmt.Sprintf("gosu postgres postgres -D /data/postgresql -p 5433 -h %s", node.PrivateIP))
+	go svisor.Run()
+
+	fmt.Println("Establishing new connection to PG")
+	conn, err := openConn(ctx, node)
+	if err != nil {
+		return fmt.Errorf("failed to establish connection to local node: %s", err)
+	}
+
+	// Blow away repmgr database
+	fmt.Println("Dropping repmgr database")
+	sql := fmt.Sprintf("DROP DATABASE repmgr;")
+	_, err = conn.Exec(ctx, sql)
+	if err != nil {
+		return fmt.Errorf("failed to drop repmgr database: %s", err)
+	}
+
+	fmt.Println("Establishing new connection to PG")
+	if err = node.createRequiredUsers(ctx, conn); err != nil {
+		return fmt.Errorf("failed creating required users: %s", err)
+	}
+
+	fmt.Println("Restore original HBA file")
+	if err := restoreHBAFile(); err != nil {
+		return fmt.Errorf("failed to restore original pg_hba.conf: %s", err)
+	}
+
+	svisor.Stop()
+
+	if err := setRestoreLock(); err != nil {
+		return fmt.Errorf("failed to set restore lock: %s", err)
+	}
+
+	return nil
+}
 
 func isActiveRestore() (bool, error) {
 	if _, err := os.Stat(restoreLockFile); err == nil {
@@ -31,71 +97,17 @@ func isActiveRestore() (bool, error) {
 	return true, nil
 }
 
-func Restore(ctx context.Context, node *Node) error {
-	fmt.Println("Backing up HBA File")
-	if err := backupHBAFile(); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("failed backing up pg_hba.conf: %s", err)
-	}
-
-	fmt.Println("Overwriting HBA file so we can update authentication")
-	if err := overwriteHBAFile(); err != nil {
-		return fmt.Errorf("failed to overwrite pg_hba.conf: %s", err)
-	}
-
-	if _, err := os.Stat("/data/postgres/standby.signal"); err == nil {
-		fmt.Println("restoring from a hot standby. clearing standby signal so we can boot.")
-		// We are restoring from a hot standby, so we need to clear the signal so we can boot.
-		if err = os.Remove("/data/postgres/standby.signal"); err != nil {
-			return fmt.Errorf("failed to remove standby signal: %s", err)
-		}
-	}
-
-	fmt.Println("Starting PG in standalone mode")
-	if err := utils.RunCommand(fmt.Sprintf("pg_ctl -D /data/postgres -h %s", node.PrivateIP)); err != nil {
-		return fmt.Errorf("failed to start standalone postgres: %s", err)
-	}
-
-	fmt.Println("Establishing new connection to PG")
-	conn, err := node.NewLocalConnection(ctx, "postgres")
-	if err != nil {
-		return fmt.Errorf("failed to establish connection to local node: %s", err)
-	}
-
-	fmt.Println("Establishing new connection to PG")
-	if err = node.createRequiredUsers(ctx, conn); err != nil {
-		return fmt.Errorf("failed creating required users: %s", err)
-	}
-
-	fmt.Println("Restore original HBA file")
-	if err := restoreHBAFile(); err != nil {
-		return fmt.Errorf("failed to restore original pg_hba.conf: %s", err)
-	}
-
-	if err := utils.RunCommand(fmt.Sprintf("pg_ctl -D /data/postgres -h %s", node.PrivateIP)); err != nil {
-		return fmt.Errorf("failed to shutdown standalone postgres: %s", err)
-	}
-
-	if err := setRestoreLock(); err != nil {
-		return fmt.Errorf("failed to set restore lock: %s", err)
-	}
-
-	return nil
-}
-
 func backupHBAFile() error {
-	if _, err := os.Stat(pathToHBAFile); os.IsNotExist(err) {
+	if _, err := os.Stat(pathToHBAFile); err != nil {
 		return err
 	}
 
-	input, err := ioutil.ReadFile(pathToHBAFile)
+	val, err := os.ReadFile(pathToHBAFile)
 	if err != nil {
 		return err
 	}
 
-	if err = ioutil.WriteFile(pathToBackup, input, 0644); err != nil {
+	if err = ioutil.WriteFile(pathToHBABackup, val, 0644); err != nil {
 		return err
 	}
 
@@ -109,7 +121,7 @@ func overwriteHBAFile() error {
 	}
 	defer file.Close()
 
-	perm := []byte("host all flypgadmin ::0/0 trust")
+	perm := []byte("host all postgres ::0/0 trust")
 	_, err = file.Write(perm)
 	if err != nil {
 		return err
@@ -119,7 +131,7 @@ func overwriteHBAFile() error {
 }
 
 func restoreHBAFile() error {
-	input, err := ioutil.ReadFile(pathToBackup)
+	input, err := os.ReadFile(pathToHBABackup)
 	if err != nil {
 		return err
 	}
@@ -135,7 +147,7 @@ func restoreHBAFile() error {
 		return err
 	}
 
-	if err := os.Remove(pathToBackup); err != nil {
+	if err := os.Remove(pathToHBABackup); err != nil {
 		return err
 	}
 
@@ -154,4 +166,30 @@ func setRestoreLock() error {
 		return err
 	}
 	return nil
+}
+
+func openConn(ctx context.Context, n *Node) (*pgx.Conn, error) {
+	mode := "any"
+
+	url := fmt.Sprintf("postgres://[%s]:5433?target_session_attrs=%s", n.PrivateIP, mode)
+	conf, err := pgx.ParseConfig(url)
+	if err != nil {
+		return nil, err
+	}
+	conf.User = "postgres"
+
+	// Allow up to 30 seconds for PG to boot and accept connections.
+	timeout := time.After(2 * time.Minute)
+	tick := time.Tick(1 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			return nil, fmt.Errorf("timed out waiting for successful connection")
+		case <-tick:
+			conn, err := pgx.ConnectConfig(ctx, conf)
+			if err == nil {
+				return conn, err
+			}
+		}
+	}
 }

--- a/internal/flypg/restore.go
+++ b/internal/flypg/restore.go
@@ -1,0 +1,157 @@
+package flypg
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/fly-apps/postgres-flex/internal/utils"
+)
+
+const (
+	pathToHBAFile   = "/data/postgres/pg_hba.conf"
+	pathToBackup    = "/data/postgres/pg_hba.conf.bak"
+	restoreLockFile = "/data/restore.lock"
+)
+
+func isActiveRestore() (bool, error) {
+	if _, err := os.Stat(restoreLockFile); err == nil {
+
+		val, err := os.ReadFile(restoreLockFile)
+		if err != nil {
+			return false, err
+		}
+
+		if string(val) == os.Getenv("FLY_APP_NAME") {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func Restore(ctx context.Context, node *Node) error {
+	fmt.Println("Backing up HBA File")
+	if err := backupHBAFile(); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed backing up pg_hba.conf: %s", err)
+	}
+
+	fmt.Println("Overwriting HBA file so we can update authentication")
+	if err := overwriteHBAFile(); err != nil {
+		return fmt.Errorf("failed to overwrite pg_hba.conf: %s", err)
+	}
+
+	if _, err := os.Stat("/data/postgres/standby.signal"); err == nil {
+		fmt.Println("restoring from a hot standby. clearing standby signal so we can boot.")
+		// We are restoring from a hot standby, so we need to clear the signal so we can boot.
+		if err = os.Remove("/data/postgres/standby.signal"); err != nil {
+			return fmt.Errorf("failed to remove standby signal: %s", err)
+		}
+	}
+
+	fmt.Println("Starting PG in standalone mode")
+	if err := utils.RunCommand(fmt.Sprintf("pg_ctl -D /data/postgres -h %s", node.PrivateIP)); err != nil {
+		return fmt.Errorf("failed to start standalone postgres: %s", err)
+	}
+
+	fmt.Println("Establishing new connection to PG")
+	conn, err := node.NewLocalConnection(ctx, "postgres")
+	if err != nil {
+		return fmt.Errorf("failed to establish connection to local node: %s", err)
+	}
+
+	fmt.Println("Establishing new connection to PG")
+	if err = node.createRequiredUsers(ctx, conn); err != nil {
+		return fmt.Errorf("failed creating required users: %s", err)
+	}
+
+	fmt.Println("Restore original HBA file")
+	if err := restoreHBAFile(); err != nil {
+		return fmt.Errorf("failed to restore original pg_hba.conf: %s", err)
+	}
+
+	if err := utils.RunCommand(fmt.Sprintf("pg_ctl -D /data/postgres -h %s", node.PrivateIP)); err != nil {
+		return fmt.Errorf("failed to shutdown standalone postgres: %s", err)
+	}
+
+	if err := setRestoreLock(); err != nil {
+		return fmt.Errorf("failed to set restore lock: %s", err)
+	}
+
+	return nil
+}
+
+func backupHBAFile() error {
+	if _, err := os.Stat(pathToHBAFile); os.IsNotExist(err) {
+		return err
+	}
+
+	input, err := ioutil.ReadFile(pathToHBAFile)
+	if err != nil {
+		return err
+	}
+
+	if err = ioutil.WriteFile(pathToBackup, input, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func overwriteHBAFile() error {
+	file, err := os.OpenFile(pathToHBAFile, os.O_RDWR|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	perm := []byte("host all flypgadmin ::0/0 trust")
+	_, err = file.Write(perm)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func restoreHBAFile() error {
+	input, err := ioutil.ReadFile(pathToBackup)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(pathToHBAFile, os.O_RDWR|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.Write(input)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(pathToBackup); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setRestoreLock() error {
+	file, err := os.OpenFile(restoreLockFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(os.Getenv("FLY_APP_NAME"))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/flypg/restore.go
+++ b/internal/flypg/restore.go
@@ -205,11 +205,15 @@ func openConn(ctx context.Context, n *Node) (*pgx.Conn, error) {
 
 func clearLocks() error {
 	if err := removeReadOnlyLock(); err != nil {
-		return fmt.Errorf("failed to remove readonly lock pre-restore: %s", err)
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove readonly lock pre-restore: %s", err)
+		}
 	}
 
 	if err := removeZombieLock(); err != nil {
-		return fmt.Errorf("failed to remove zombie lock pre-restore: %s", err)
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove zombie lock pre-restore: %s", err)
+		}
 	}
 
 	return nil

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -9,9 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fly-apps/postgres-flex/internal/flypg"
-
-	"github.com/fly-apps/postgres-flex/internal/api"
 	"github.com/google/shlex"
 	"golang.org/x/sync/errgroup"
 )
@@ -126,10 +123,6 @@ func (h *Supervisor) waitForExit(ctx context.Context) {
 	for _, proc := range h.procs {
 		go proc.Kill()
 	}
-}
-
-func (h *Supervisor) StartHttpListener(node *flypg.Node) {
-	go api.StartHttpServer(node)
 }
 
 func (h *Supervisor) Run() error {


### PR DESCRIPTION
This adds support for Fly-based volume restores.  

### How it works

The initial cue for kicking off a restore is the presence of the `FLY_RESTORED_FROM` environment variable.  When this environment variable is present, we will push through the following process.  

1. Check to see if the `restore.lock` file exists.  The restore process will begin if the `restore.lock` file does not exist, or it exists but its value does not match the name of our app.
2. Reconfigure the `pg_hba.conf` file so we can bypass authentication locally.
3. Boot Postgres into standalone mode.
4. Create and update the `flypgadmin`, `repmgr` and `postgres` users and ensure their credentials match the current environment.   
5. The `repmgr` database will be dropped so we can start a fresh cluster setup.
6. Revert the `pg_hba.conf` file back to its original configuration.
7.  Shutdown the standalone Postgres 
8. Create the `restore.lock` file and set its value to the name of our app.  This will ensure the restore process isn't retried.
9.  Begin the normal boot process. 

### Notes

* When restoring from a snapshot using `flyctl`, it's recommended that you restore into a single node cluster.  Scale-out as needed once the restore completes.   
* The credentials for the `flypgadmin`, `repmgr` and `postgres` will not be persisted across restores.  