### PR TITLE
Alarms health check

### DIFF
--- a/internal/flycheck/pg.go
+++ b/internal/flycheck/pg.go
@@ -26,20 +26,9 @@ func CheckPostgreSQL(ctx context.Context, checks *check.CheckSuite) (*check.Chec
 		return checks, errors.Wrap(err, "failed to connect with local node")
 	}
 
-	repConn, err := node.RepMgr.NewLocalConnection(ctx)
-	if err != nil {
-		return checks, fmt.Errorf("failed to connect to repmgr node: %s", err)
-	}
-
-	member, err := node.RepMgr.Member(ctx, repConn)
-	if err != nil {
-		return checks, fmt.Errorf("failed to resolve local member role: %s", err)
-	}
-
 	// Cleanup connections
 	checks.OnCompletion = func() {
 		localConn.Close(ctx)
-		repConn.Close(ctx)
 	}
 
 	checks.AddCheck("locks", func() (string, error) {

--- a/internal/flycheck/pg.go
+++ b/internal/flycheck/pg.go
@@ -31,14 +31,14 @@ func CheckPostgreSQL(ctx context.Context, checks *check.CheckSuite) (*check.Chec
 		localConn.Close(ctx)
 	}
 
-	checks.AddCheck("locks", func() (string, error) {
+	checks.AddCheck("alarms", func() (string, error) {
 		locks := []string{}
 
 		if flypg.ZombieLockExists() {
 			locks = append(locks, "zombie")
 		}
 		if flypg.ReadOnlyLockExists() {
-			locks = append(locks, "read-only")
+			locks = append(locks, "capacity")
 		}
 
 		if len(locks) > 0 {
@@ -46,7 +46,7 @@ func CheckPostgreSQL(ctx context.Context, checks *check.CheckSuite) (*check.Chec
 			return "", fmt.Errorf(lockStr)
 		}
 
-		return "no locks detected", nil
+		return "no alarms triggered", nil
 
 	})
 

--- a/internal/flycheck/vm.go
+++ b/internal/flycheck/vm.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"runtime"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -163,33 +161,6 @@ func diskUsage(dir string) (size uint64, available uint64, err error) {
 	available = stat.Bavail * uint64(stat.Bsize)
 
 	return size, available, nil
-}
-
-func round(val float64, roundOn float64, places int) (newVal float64) {
-	var round float64
-	pow := math.Pow(10, float64(places))
-	digit := pow * val
-	_, div := math.Modf(digit)
-	if div >= roundOn {
-		round = math.Ceil(digit)
-	} else {
-		round = math.Floor(digit)
-	}
-	newVal = round / pow
-	return
-}
-func dataSize(size uint64) string {
-	var suffixes [5]string
-	suffixes[0] = "B"
-	suffixes[1] = "KB"
-	suffixes[2] = "MB"
-	suffixes[3] = "GB"
-	suffixes[4] = "TB"
-
-	base := math.Log(float64(size)) / math.Log(1024)
-	getSize := round(math.Pow(1024, base-math.Floor(base)), .5, 2)
-	getSuffix := suffixes[int(math.Floor(base))]
-	return fmt.Sprint(strconv.FormatFloat(getSize, 'f', -1, 64) + " " + getSuffix)
 }
 
 func pressureToDuration(pressure float64, base float64) (time.Duration, error) {

--- a/internal/flypg/node.go
+++ b/internal/flypg/node.go
@@ -128,6 +128,11 @@ func (n *Node) Init(ctx context.Context) error {
 		return err
 	}
 
+	// Create locks directory if it doesn't already exist.
+	if err := createLocksDir(); err != nil {
+		return err
+	}
+
 	// Initiate a restore
 	if os.Getenv("FLY_RESTORED_FROM") != "" {
 		// Check to see if there's an active restore.
@@ -737,4 +742,16 @@ func setDirOwnership() error {
 	cmd := exec.Command("sh", "-c", cmdStr)
 	_, err = cmd.Output()
 	return err
+}
+
+func createLocksDir() error {
+	_, err := os.Stat("/data/locks")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return utils.RunCommand("mkdir /data/locks")
+		}
+		return err
+	}
+
+	return nil
 }

--- a/internal/flypg/readonly.go
+++ b/internal/flypg/readonly.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	readOnlyLockFile = "/data/readonly.lock"
+	readOnlyLockFile = "/data/locks/readonly.lock"
+
 	readOnlyEnabled  = "on"
 	readOnlyDisabled = "off"
 

--- a/internal/flypg/readonly.go
+++ b/internal/flypg/readonly.go
@@ -13,9 +13,6 @@ import (
 const (
 	readOnlyLockFile = "/data/locks/readonly.lock"
 
-	readOnlyEnabled  = "on"
-	readOnlyDisabled = "off"
-
 	ReadOnlyStateEndpoint    = "commands/admin/readonly/state"
 	BroadcastEnableEndpoint  = "commands/admin/readonly/enable"
 	BroadcastDisableEndpoint = "commands/admin/readonly/disable"

--- a/internal/flypg/restore.go
+++ b/internal/flypg/restore.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
+	restoreLockFile = "/data/locks/restore.lock"
+
 	pathToHBAFile   = "/data/postgresql/pg_hba.conf"
 	pathToHBABackup = "/data/postgresql/pg_hba.conf.bak"
-	restoreLockFile = "/data/restore.lock"
 )
 
 func Restore(ctx context.Context, node *Node) error {

--- a/internal/flypg/zombie.go
+++ b/internal/flypg/zombie.go
@@ -10,6 +10,8 @@ import (
 )
 
 var (
+	zombieLockFile = "/data/locks/zombie.lock"
+
 	// ErrZombieLockRegionMismatch - The region associated with the resolved primary does not match our PRIMARY_REGION.
 	ErrZombieLockRegionMismatch = errors.New("resolved primary does not reside within our PRIMARY_REGION")
 	// ErrZombieLockPrimaryMismatch - The primary listed within the zombie.lock file is no longer identifying
@@ -22,7 +24,7 @@ var (
 )
 
 func ZombieLockExists() bool {
-	_, err := os.Stat("/data/zombie.lock")
+	_, err := os.Stat(zombieLockFile)
 	if os.IsNotExist(err) {
 		return false
 	}
@@ -30,7 +32,7 @@ func ZombieLockExists() bool {
 }
 
 func writeZombieLock(hostname string) error {
-	if err := os.WriteFile("/data/zombie.lock", []byte(hostname), 0644); err != nil {
+	if err := os.WriteFile(zombieLockFile, []byte(hostname), 0644); err != nil {
 		return err
 	}
 
@@ -38,7 +40,7 @@ func writeZombieLock(hostname string) error {
 }
 
 func RemoveZombieLock() error {
-	if err := os.Remove("/data/zombie.lock"); err != nil {
+	if err := os.Remove(zombieLockFile); err != nil {
 		return err
 	}
 
@@ -46,7 +48,7 @@ func RemoveZombieLock() error {
 }
 
 func ReadZombieLock() (string, error) {
-	body, err := os.ReadFile("/data/zombie.lock")
+	body, err := os.ReadFile(zombieLockFile)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Notable changes:

* Role will always represent the value repmgr presents.
* Alarms health-check was added to convey cluster-wide issues that need to be addressed.
* Moved capacity check back to the VM checks and shown for all members.