### PR TITLE
Cleaning up monitoring tasks

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"github.com/fly-apps/postgres-flex/internal/flypg"
@@ -21,15 +20,19 @@ var (
 
 func main() {
 	ctx := context.Background()
+
 	node, err := flypg.NewNode()
 	if err != nil {
-		fmt.Printf("failed to reference node: %s\n", err)
-		os.Exit(1)
+		panic(fmt.Sprintf("failed to reference node: %s\n", err))
 	}
 
 	// Dead member monitor
 	log.Println("Monitoring dead members")
-	go monitorDeadMembers(ctx, node)
+	go func() {
+		if err := monitorDeadMembers(ctx, node); err != nil {
+			panic(err)
+		}
+	}()
 
 	// Readonly monitor
 	log.Println("Monitoring readonly state")

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -2,218 +2,40 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
+	"log"
 	"os"
 	"time"
 
 	"github.com/fly-apps/postgres-flex/internal/flypg"
-	"github.com/fly-apps/postgres-flex/internal/flypg/admin"
-	"github.com/jackc/pgx/v5"
-
-	"golang.org/x/exp/maps"
 )
 
 var (
-	deadMemberMonitorFrequency    = time.Minute * 5
-	readonlyStateMonitorFrequency = time.Minute * 1
+	deadMemberMonitorFrequency       = time.Hour * 1
+	replicationStateMonitorFrequency = time.Hour * 1
+	readonlyStateMonitorFrequency    = time.Minute * 1
+
+	defaultDeadMemberRemovalThreshold   = time.Hour * 12
+	defaultInactiveSlotRemovalThreshold = time.Hour * 12
 )
 
 func main() {
 	ctx := context.Background()
-	flypgNode, err := flypg.NewNode()
+	node, err := flypg.NewNode()
 	if err != nil {
 		fmt.Printf("failed to reference node: %s\n", err)
 		os.Exit(1)
 	}
 
 	// Dead member monitor
-	go func() {
-		internal, err := flypg.ReadFromFile("/data/flypg.internal.conf")
-		if err != nil {
-			fmt.Printf("failed to open config: %s\n", err)
-			os.Exit(1)
-		}
-
-		user, err := flypg.ReadFromFile("/data/flypg.user.conf")
-		if err != nil {
-			fmt.Printf("failed to open config: %s\n", err)
-			os.Exit(1)
-		}
-
-		maps.Copy(user, internal)
-
-		deadMemberRemovalThreshold, err := time.ParseDuration(fmt.Sprint(internal["standby_clean_interval"]))
-		if err != nil {
-			fmt.Printf(fmt.Sprintf("Failed to parse config: %s", err))
-			os.Exit(1)
-		}
-
-		seenAt := map[int]time.Time{}
-
-		ticker := time.NewTicker(deadMemberMonitorFrequency)
-		defer ticker.Stop()
-
-		fmt.Printf("Pruning every %s...\n", deadMemberRemovalThreshold)
-
-		for range ticker.C {
-			err := handleDeadMemberMonitorTick(ctx, flypgNode, seenAt, deadMemberRemovalThreshold)
-			if err != nil {
-				fmt.Println(err)
-			}
-		}
-	}()
+	log.Println("Monitoring dead members")
+	go monitorDeadMembers(ctx, node)
 
 	// Readonly monitor
-	ticker := time.NewTicker(readonlyStateMonitorFrequency)
-	defer ticker.Stop()
-	for range ticker.C {
-		if err := handleReadonlyMonitorTick(ctx, flypgNode); err != nil {
-			fmt.Println(err)
-		}
-	}
+	log.Println("Monitoring readonly state")
+	go monitorReadOnly(ctx, node)
 
-}
-
-type readonlyStateResponse struct {
-	Result bool
-}
-
-func handleReadonlyMonitorTick(ctx context.Context, node *flypg.Node) error {
-	conn, err := node.RepMgr.NewLocalConnection(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to open local connection: %s", err)
-	}
-	defer conn.Close(ctx)
-
-	member, err := node.RepMgr.Member(ctx, conn)
-	if err != nil {
-		return fmt.Errorf("failed to query local member: %s", err)
-	}
-
-	if member.Role == flypg.PrimaryRoleName {
-		return nil
-	}
-
-	primary, err := node.RepMgr.PrimaryMember(ctx, conn)
-	if err != nil {
-		return fmt.Errorf("failed to query primary member: %s", err)
-	}
-
-	endpoint := fmt.Sprintf("http://[%s]:5500/%s", primary.Hostname, flypg.ReadOnlyStateEndpoint)
-	resp, err := http.Get(endpoint)
-	if err != nil {
-		return fmt.Errorf("failed to query primary readonly state: %s", err)
-	}
-	defer resp.Body.Close()
-
-	var state readonlyStateResponse
-	if err := json.NewDecoder(resp.Body).Decode(&state); err != nil {
-		return fmt.Errorf("failed to decode result: %s", err)
-	}
-
-	if state.Result {
-		if !flypg.ReadOnlyLockExists() {
-			fmt.Printf("Setting connections running under %s to readonly\n", node.PrivateIP)
-			if err := flypg.EnableReadonly(ctx, node); err != nil {
-				return fmt.Errorf("failed to set connection under %s to readonly: %s", node.PrivateIP, err)
-			}
-		}
-	} else {
-		if !flypg.ZombieLockExists() && flypg.ReadOnlyLockExists() {
-			fmt.Printf("Setting connections running under %s to read/write\n", node.PrivateIP)
-			if err := flypg.DisableReadonly(ctx, node); err != nil {
-				return fmt.Errorf("failed to set connections under %s read/write: %s", node.PrivateIP, err)
-			}
-		}
-	}
-
-	return nil
-}
-
-func handleDeadMemberMonitorTick(ctx context.Context, node *flypg.Node, seenAt map[int]time.Time, deadMemberRemovalThreshold time.Duration) error {
-	// TODO - We should connect using the flypgadmin user so we can  differentiate between
-	// internal admin connection usage and the actual repmgr process.
-	conn, err := node.RepMgr.NewLocalConnection(ctx)
-	if err != nil {
-		fmt.Printf("failed to open local connection: %s\n", err)
-		os.Exit(1)
-	}
-	defer conn.Close(ctx)
-
-	member, err := node.RepMgr.MemberByID(ctx, conn, int(node.RepMgr.ID))
-	if err != nil {
-		return err
-	}
-
-	if member.Role != flypg.PrimaryRoleName {
-		return nil
-	}
-
-	standbys, err := node.RepMgr.StandbyMembers(ctx, conn)
-	if err != nil {
-		return fmt.Errorf("failed to query standbys: %s", err)
-	}
-
-	for _, standby := range standbys {
-		sConn, err := node.RepMgr.NewRemoteConnection(ctx, standby.Hostname)
-		if err != nil {
-			// TODO - Verify the exception that's getting thrown.
-			if time.Since(seenAt[standby.ID]) >= deadMemberRemovalThreshold {
-				if err := node.RepMgr.UnregisterMember(ctx, standby); err != nil {
-					fmt.Printf("failed to unregister member %s: %v", standby.Hostname, err)
-					continue
-				}
-
-				delete(seenAt, standby.ID)
-			}
-
-			continue
-		}
-		defer sConn.Close(ctx)
-
-		seenAt[standby.ID] = time.Now()
-	}
-
-	removeOrphanedReplicationSlots(ctx, conn, standbys)
-
-	return nil
-}
-
-func removeOrphanedReplicationSlots(ctx context.Context, conn *pgx.Conn, standbys []flypg.Member) {
-	var orphanedSlots []admin.ReplicationSlot
-
-	slots, err := admin.ListReplicationSlots(ctx, conn)
-	if err != nil {
-		fmt.Printf("failed to list replication slots: %s", err)
-	}
-
-	// An orphaned replication slot is defined as an inactive replication slot that is no longer tied to
-	// and existing repmgr member.
-	for _, slot := range slots {
-		matchFound := false
-		for _, standby := range standbys {
-			if slot.MemberID == int32(standby.ID) {
-				matchFound = true
-			}
-		}
-
-		if !matchFound && !slot.Active {
-			orphanedSlots = append(orphanedSlots, slot)
-		}
-	}
-
-	if len(orphanedSlots) > 0 {
-		fmt.Printf("%d orphaned replication slot(s) detected\n", len(orphanedSlots))
-
-		for _, slot := range orphanedSlots {
-			fmt.Printf("Dropping replication slot: %s\n", slot.Name)
-
-			if err := admin.DropReplicationSlot(ctx, conn, slot.Name); err != nil {
-				fmt.Printf("failed to drop replication slot %s: %v\n", slot.Name, err)
-				continue
-			}
-		}
-	}
+	// Replication slot monitor
+	log.Println("Monitoring replication slots")
+	monitorReplicationSlots(ctx, node)
 }

--- a/cmd/monitor/monitor_dead_members.go
+++ b/cmd/monitor/monitor_dead_members.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/fly-apps/postgres-flex/internal/flypg"
+	"golang.org/x/exp/maps"
+)
+
+func monitorDeadMembers(ctx context.Context, node *flypg.Node) error {
+	internal, err := flypg.ReadFromFile("/data/flypg.internal.conf")
+	if err != nil {
+		return fmt.Errorf("failed to open config: %s", err)
+	}
+
+	user, err := flypg.ReadFromFile("/data/flypg.user.conf")
+	if err != nil {
+		return fmt.Errorf("failed to open config: %s", err)
+	}
+
+	maps.Copy(user, internal)
+
+	removalThreshold := defaultDeadMemberRemovalThreshold
+
+	if internal["deadMemberRemovalThreshold"] != "" {
+		removalThreshold, err = time.ParseDuration(fmt.Sprint(internal["deadMemberRemovalThreshold"]))
+		if err != nil {
+			log.Printf("failed to parse deadMemberRemovalThreshold: %s\n", err)
+		}
+	}
+
+	seenAt := map[int]time.Time{}
+
+	ticker := time.NewTicker(deadMemberMonitorFrequency)
+	defer ticker.Stop()
+
+	log.Printf("Pruning every %s...\n", removalThreshold)
+
+	for range ticker.C {
+		err := deadMemberMonitorTick(ctx, node, seenAt, removalThreshold)
+		if err != nil {
+			log.Printf("deadMemberMonitorTick failed with: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func deadMemberMonitorTick(ctx context.Context, node *flypg.Node, seenAt map[int]time.Time, deadMemberRemovalThreshold time.Duration) error {
+	// TODO - We should connect using the flypgadmin user so we can  differentiate between
+	// internal admin connection usage and the actual repmgr process.
+	conn, err := node.RepMgr.NewLocalConnection(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to open local connection: %s", err)
+	}
+	defer conn.Close(ctx)
+
+	member, err := node.RepMgr.MemberByID(ctx, conn, int(node.RepMgr.ID))
+	if err != nil {
+		return err
+	}
+
+	if member.Role != flypg.PrimaryRoleName {
+		return nil
+	}
+
+	standbys, err := node.RepMgr.StandbyMembers(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("failed to query standbys: %s", err)
+	}
+
+	for _, standby := range standbys {
+		sConn, err := node.RepMgr.NewRemoteConnection(ctx, standby.Hostname)
+		if err != nil {
+			// TODO - Verify the exception that's getting thrown.
+			if time.Since(seenAt[standby.ID]) >= deadMemberRemovalThreshold {
+				log.Printf("Removing dead member: %s\n", standby.Hostname)
+				if err := node.RepMgr.UnregisterMember(ctx, standby); err != nil {
+					log.Printf("failed to unregister member %s: %v", standby.Hostname, err)
+					continue
+				}
+				delete(seenAt, standby.ID)
+			}
+
+			continue
+		}
+		defer sConn.Close(ctx)
+		seenAt[standby.ID] = time.Now()
+	}
+
+	return nil
+}

--- a/cmd/monitor/monitor_readonly.go
+++ b/cmd/monitor/monitor_readonly.go
@@ -15,7 +15,7 @@ type readonlyStateResponse struct {
 	Result bool
 }
 
-func monitorReadOnly(ctx context.Context, node *flypg.Node) error {
+func monitorReadOnly(ctx context.Context, node *flypg.Node) {
 	ticker := time.NewTicker(readonlyStateMonitorFrequency)
 	defer ticker.Stop()
 	for range ticker.C {
@@ -23,8 +23,6 @@ func monitorReadOnly(ctx context.Context, node *flypg.Node) error {
 			log.Printf("readOnlyMonitorTick failed with: %s", err)
 		}
 	}
-
-	return nil
 }
 
 func readonlyMonitorTick(ctx context.Context, node *flypg.Node) error {

--- a/cmd/monitor/monitor_readonly.go
+++ b/cmd/monitor/monitor_readonly.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/fly-apps/postgres-flex/internal/flypg"
+)
+
+type readonlyStateResponse struct {
+	Result bool
+}
+
+func monitorReadOnly(ctx context.Context, node *flypg.Node) error {
+	ticker := time.NewTicker(readonlyStateMonitorFrequency)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := readonlyMonitorTick(ctx, node); err != nil {
+			log.Printf("readOnlyMonitorTick failed with: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func readonlyMonitorTick(ctx context.Context, node *flypg.Node) error {
+	conn, err := node.RepMgr.NewLocalConnection(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to open local connection: %s", err)
+	}
+	defer conn.Close(ctx)
+
+	member, err := node.RepMgr.Member(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("failed to query local member: %s", err)
+	}
+
+	if member.Role == flypg.PrimaryRoleName {
+		return nil
+	}
+
+	primary, err := node.RepMgr.PrimaryMember(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("failed to query primary member: %s", err)
+	}
+
+	endpoint := fmt.Sprintf("http://[%s]:5500/%s", primary.Hostname, flypg.ReadOnlyStateEndpoint)
+	resp, err := http.Get(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to query primary readonly state: %s", err)
+	}
+	defer resp.Body.Close()
+
+	var state readonlyStateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&state); err != nil {
+		return fmt.Errorf("failed to decode result: %s", err)
+	}
+
+	if state.Result {
+		if !flypg.ReadOnlyLockExists() {
+			log.Printf("Setting connections running under %s to readonly\n", node.PrivateIP)
+			if err := flypg.EnableReadonly(ctx, node); err != nil {
+				return fmt.Errorf("failed to set connection under %s to readonly: %s", node.PrivateIP, err)
+			}
+		}
+	} else {
+		if !flypg.ZombieLockExists() && flypg.ReadOnlyLockExists() {
+			log.Printf("Setting connections running under %s to read/write\n", node.PrivateIP)
+			if err := flypg.DisableReadonly(ctx, node); err != nil {
+				return fmt.Errorf("failed to set connections under %s read/write: %s", node.PrivateIP, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/monitor/monitor_replication_slots.go
+++ b/cmd/monitor/monitor_replication_slots.go
@@ -64,6 +64,7 @@ func replicationSlotMonitorTick(ctx context.Context, node *flypg.Node, inactiveS
 		if lastSeen, ok := inactiveSlotStatus[int(slot.MemberID)]; ok {
 			// TODO - Consider creating a separate threshold for when the member exists.
 			// TODO - Consider being more aggressive with removing replication slots if disk capacity is at dangerous levels.
+			// TODO - Make inactiveSlotRemovalThreshold configurable.
 
 			// Remove the replication slot if it has been inactive for longer than the defined threshold
 			if time.Since(lastSeen) > defaultInactiveSlotRemovalThreshold {

--- a/cmd/monitor/monitor_replication_slots.go
+++ b/cmd/monitor/monitor_replication_slots.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fly-apps/postgres-flex/internal/flypg/admin"
 )
 
-func monitorReplicationSlots(ctx context.Context, node *flypg.Node) error {
+func monitorReplicationSlots(ctx context.Context, node *flypg.Node) {
 	inactiveSlotStatus := map[int]time.Time{}
 
 	ticker := time.NewTicker(replicationStateMonitorFrequency)
@@ -19,8 +19,6 @@ func monitorReplicationSlots(ctx context.Context, node *flypg.Node) error {
 			log.Printf("replicationSlotMonitorTick failed with: %s", err)
 		}
 	}
-
-	return nil
 }
 
 func replicationSlotMonitorTick(ctx context.Context, node *flypg.Node, inactiveSlotStatus map[int]time.Time) error {

--- a/cmd/monitor/monitor_replication_slots.go
+++ b/cmd/monitor/monitor_replication_slots.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/fly-apps/postgres-flex/internal/flypg"
+	"github.com/fly-apps/postgres-flex/internal/flypg/admin"
+)
+
+func monitorReplicationSlots(ctx context.Context, node *flypg.Node) error {
+	inactiveSlotStatus := map[int]time.Time{}
+
+	ticker := time.NewTicker(replicationStateMonitorFrequency)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := replicationSlotMonitorTick(ctx, node, inactiveSlotStatus); err != nil {
+			log.Printf("replicationSlotMonitorTick failed with: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func replicationSlotMonitorTick(ctx context.Context, node *flypg.Node, inactiveSlotStatus map[int]time.Time) error {
+	conn, err := node.RepMgr.NewLocalConnection(ctx)
+	if err != nil {
+		log.Printf("failed to open local connection: %s\n", err)
+	}
+	defer conn.Close(ctx)
+
+	member, err := node.RepMgr.Member(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	// Only monitor replication slots on the primary.
+	// We need to check this per-tick as the role can change at runtime.
+	if member.Role != flypg.PrimaryRoleName {
+		return nil
+	}
+
+	slots, err := admin.ListReplicationSlots(ctx, conn)
+	if err != nil {
+		log.Printf("failed to list replication slots: %s\n", err)
+	}
+
+	for _, slot := range slots {
+		// Cleanup inactive replication slots so we don't inadvertantly run ourselves out of disk space.
+		if !slot.Active {
+			if slot.RetainedWalInBytes != 0 {
+				retainedWalInMB := slot.RetainedWalInBytes / 1024 / 1024
+				log.Printf("warning: inactive replication slot %s is retaining %d MB of WAL", slot.Name, retainedWalInMB)
+			}
+
+			// Check to see if slot has already been registered as inactive.
+			if lastSeen, ok := inactiveSlotStatus[int(slot.MemberID)]; ok {
+				// TODO - Consider creating a separate threshold for when the member exists.
+				// TODO - Consider being more aggressive with removing replication slots if disk
+				// capacity is at dangerous levels.
+
+				// Remove the replication slot if it has been inactive for longer than the defined threshold
+				if time.Since(lastSeen) > defaultInactiveSlotRemovalThreshold {
+					log.Printf("Dropping replication slot: %s\n", slot.Name)
+					if err := admin.DropReplicationSlot(ctx, conn, slot.Name); err != nil {
+						log.Printf("failed to drop replication slot %s: %v\n", slot.Name, err)
+						continue
+					}
+					delete(inactiveSlotStatus, int(slot.MemberID))
+				}
+			} else {
+				inactiveSlotStatus[int(slot.MemberID)] = time.Now()
+			}
+		} else {
+			delete(inactiveSlotStatus, int(slot.MemberID))
+		}
+	}
+
+	return nil
+}

--- a/internal/flypg/flypg.go
+++ b/internal/flypg/flypg.go
@@ -18,7 +18,7 @@ type FlyPGConfig struct {
 
 func (c *FlyPGConfig) SetDefaults() {
 	c.internalConfig = ConfigMap{
-		"standby_clean_interval": time.Hour * 24,
+		"deadMemberRemovalThreshold": time.Hour * 24,
 	}
 }
 


### PR DESCRIPTION
Separates the various monitoring tasks into their own go routines.  

Addresses the race condition here: https://github.com/fly-apps/postgres-flex/issues/65