### PR TITLE
Timescaledb support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,21 +32,6 @@ jobs:
         id: get-latest-tag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
       -
-        name: Build and push Postgres 14
-        id: docker_build_14
-        uses: docker/build-push-action@v3
-        with:
-          build-args: |
-            PG_VERSION=14.6
-            PG_MAJOR_VERSION=14
-            VERSION=${{ steps.get-latest-tag.outputs.tag }}
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: |
-            flyio/postgres-flex:14
-            flyio/postgres-flex:14.6
-      -
         name: Build and push Postgres 15
         id: docker_build_15
         uses: docker/build-push-action@v3
@@ -62,8 +47,23 @@ jobs:
             flyio/postgres-flex:15
             flyio/postgres-flex:15.1
       -
-        name: Postgres 14 Image digest
-        run: echo ${{ steps.docker_build_14.outputs.digest }}
+        name: Build and push Postgres 15 Timescale DB
+        id: docker_build_15_timescaledb
+        uses: docker/build-push-action@v3
+        with:
+          build-args: |
+            PG_VERSION=15.1
+            PG_MAJOR_VERSION=15
+            VERSION=${{ steps.get-latest-tag.outputs.tag }}
+          context: .
+          file: ./Dockerfile-timescaledb
+          push: true
+          tags: |
+            flyio/postgres-flex-timescaledb:15
+            flyio/postgres-flex-timescaledb:15.1
       -
         name: Postgres 15 Image digest
         run: echo ${{ steps.docker_build_15.outputs.digest }}
+      -
+        name: Postgres 15 TimescaleDB Image digest
+        run: echo ${{ steps.docker_build_15_timescaledb.outputs.digest }}

--- a/Dockerfile-timescaledb
+++ b/Dockerfile-timescaledb
@@ -1,0 +1,60 @@
+ARG PG_VERSION=15.1
+ARG PG_MAJOR_VERSION=15
+ARG VERSION=custom
+
+FROM golang:1.19 as flyutil
+
+WORKDIR /go/src/github.com/fly-examples/fly-postgres
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/event_handler ./cmd/event_handler
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/failover_validation ./cmd/failover_validation
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/pg_unregister ./cmd/pg_unregister
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start_monitor ./cmd/monitor
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start_admin_server ./cmd/admin_server
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o /fly/bin/start ./cmd/start
+
+COPY ./bin/* /fly/bin/
+
+FROM wrouesnel/postgres_exporter:latest AS postgres_exporter
+
+FROM postgres:${PG_VERSION}
+ENV PGDATA=/data/postgresql
+ARG VERSION
+ARG PG_MAJOR_VERSION
+ARG POSTGIS_MAJOR=3
+
+
+LABEL fly.app_role=postgres_cluster
+LABEL fly.version=${VERSION}
+LABEL fly.pg-version=${PG_VERSION}
+LABEL fly.pg-manager=repmgr
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    ca-certificates iproute2 postgresql-$PG_MAJOR_VERSION-repmgr curl bash dnsutils vim procps jq pgbouncer ssh \
+    && apt autoremove -y
+
+RUN echo "deb https://packagecloud.io/timescale/timescaledb/debian/ $(cat /etc/os-release | grep VERSION_CODENAME | cut -d'=' -f2) main" > /etc/apt/sources.list.d/timescaledb.list \
+    && curl -L https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    postgresql-$PG_MAJOR_VERSION-postgis-$POSTGIS_MAJOR \
+    postgresql-$PG_MAJOR_VERSION-postgis-$POSTGIS_MAJOR-scripts \
+    timescaledb-2-postgresql-$PG_MAJOR_VERSION \
+    timescaledb-toolkit-postgresql-$PG_MAJOR_VERSION \
+    && apt autoremove -y
+
+COPY --from=0 /fly/bin/* /usr/local/bin
+COPY --from=postgres_exporter /postgres_exporter /usr/local/bin/
+
+ADD /config/* /fly/
+
+RUN mkdir -p /run/haproxy/
+RUN usermod -d /data postgres
+
+ENV TIMESCALEDB_ENABLED=true
+
+EXPOSE 5432
+
+
+CMD ["start"]

--- a/internal/flypg/pg.go
+++ b/internal/flypg/pg.go
@@ -220,6 +220,12 @@ func (c *PGConfig) SetDefaults() error {
 	}
 	sharedBuffersMb := sharedBuffersBytes / (1024 * 1024)
 
+	sharedPreloadLibraries := []string{"repmgr"}
+	// preload timescaledb if enabled
+	if os.Getenv("TIMESCALEDB_ENABLED") == "true" {
+		sharedPreloadLibraries = append(sharedPreloadLibraries, "timescaledb")
+	}
+
 	conf := ConfigMap{
 		"random_page_cost":         "1.1",
 		"port":                     c.port,
@@ -234,7 +240,7 @@ func (c *PGConfig) SetDefaults() error {
 		"hot_standby":              true,
 		"archive_mode":             true,
 		"archive_command":          "'/bin/true'",
-		"shared_preload_libraries": "repmgr",
+		"shared_preload_libraries": strings.Join(sharedPreloadLibraries, ", "),
 	}
 
 	c.internalConfig = conf

--- a/internal/flypg/pg.go
+++ b/internal/flypg/pg.go
@@ -240,7 +240,7 @@ func (c *PGConfig) SetDefaults() error {
 		"hot_standby":              true,
 		"archive_mode":             true,
 		"archive_command":          "'/bin/true'",
-		"shared_preload_libraries": strings.Join(sharedPreloadLibraries, ", "),
+		"shared_preload_libraries": fmt.Sprintf("'%s'", strings.Join(sharedPreloadLibraries, ",")),
 	}
 
 	c.internalConfig = conf


### PR DESCRIPTION
This adds TimescaleDB support under the image: `flyio/postgres-flex-timescaledb`.  Timescale can take a while to support newer major versions of Postgres, so we want to make sure we are not tied to their release-cycle 