### PR TITLE
Grant normal users access to the public schema

### DIFF
--- a/internal/api/handle_databases.go
+++ b/internal/api/handle_databases.go
@@ -84,7 +84,7 @@ func handleCreateDatabase(w http.ResponseWriter, r *http.Request) {
 	}
 	defer close()
 
-	if err = admin.GrantCreateOnPublic(ctx, dbConn); err != nil {
+	if err := admin.GrantCreateOnPublic(ctx, dbConn); err != nil {
 		renderErr(w, err)
 		return
 	}

--- a/internal/flypg/admin/admin.go
+++ b/internal/flypg/admin/admin.go
@@ -11,7 +11,6 @@ import (
 
 func GrantAccess(ctx context.Context, pg *pgx.Conn, username string) error {
 	sql := fmt.Sprintf("GRANT pg_read_all_data, pg_write_all_data TO %q", username)
-
 	_, err := pg.Exec(ctx, sql)
 	return err
 }
@@ -63,6 +62,16 @@ func CreateDatabase(ctx context.Context, pg *pgx.Conn, name string) error {
 
 	sql := fmt.Sprintf("CREATE DATABASE %s;", name)
 	_, err = pg.Exec(ctx, sql)
+	return err
+}
+
+// PG 15 by default removes the ability for normal users to create
+// tables within the public schema. This re-enables it to keep the
+// experience consistent for users.  We should explore create user
+// schemas for better isolation in the future.
+func GrantCreateOnPublic(ctx context.Context, pg *pgx.Conn) error {
+	sql := fmt.Sprintf(`GRANT CREATE on SCHEMA PUBLIC to PUBLIC;`)
+	_, err := pg.Exec(ctx, sql)
 	return err
 }
 

--- a/internal/flypg/admin/admin.go
+++ b/internal/flypg/admin/admin.go
@@ -65,12 +65,10 @@ func CreateDatabase(ctx context.Context, pg *pgx.Conn, name string) error {
 	return err
 }
 
-// PG 15 by default removes the ability for normal users to create
-// tables within the public schema. This re-enables it to keep the
-// experience consistent for users.  We should explore create user
-// schemas for better isolation in the future.
+// GrantCreateOnPublic re-enables the public schema for normal users.
+// We should look into creating better isolation in the future.
 func GrantCreateOnPublic(ctx context.Context, pg *pgx.Conn) error {
-	sql := fmt.Sprintf(`GRANT CREATE on SCHEMA PUBLIC to PUBLIC;`)
+	sql := "GRANT CREATE on SCHEMA PUBLIC to PUBLIC;"
 	_, err := pg.Exec(ctx, sql)
 	return err
 }


### PR DESCRIPTION
This re-enables the public schema for normal users which was disabled by default in PG 15.  This will ensure a consistent experience for users who migrate to PG 15 from earlier versions where the public schema is enabled by default.  

We should explore more secure schema patterns in the future: https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PATTERNS