### PR TITLE
Remove flag that's no longer being used

### DIFF
--- a/cmd/event_handler/main.go
+++ b/cmd/event_handler/main.go
@@ -17,10 +17,6 @@ const eventLogFile = "/data/event.log"
 func main() {
 	event := flag.String("event", "", "event type")
 	nodeID := flag.Int("node-id", 0, "the node id")
-	// This might not actually always be the new primary. %p from repmgr is variably the new or
-	// old primary. In the events that we subscribe to it's always either empty or the new primary.
-	// In the future if we subscribe to repmgrd_failover_promote, then we would have to change this
-	// name.
 	success := flag.String("success", "", "success (1) failure (0)")
 	details := flag.String("details", "", "details")
 	flag.Parse()

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -144,7 +144,7 @@ func (r *RepMgr) setDefaults() {
 		"use_replication_slots":        "yes",
 		"promote_command":              fmt.Sprintf("'repmgr standby promote -f %s --log-to-file'", r.ConfigPath),
 		"follow_command":               fmt.Sprintf("'repmgr standby follow -f %s --log-to-file --upstream-node-id=%%n'", r.ConfigPath),
-		"event_notification_command":   fmt.Sprintf("'/usr/local/bin/event_handler -node-id %%n -event %%e -success %%s -details \"%%d\""),
+		"event_notification_command":   fmt.Sprintf("'/usr/local/bin/event_handler -node-id %%n -event %%e -success %%s -details \"%%d\"'"),
 		"event_notifications":          "'child_node_disconnect,child_node_reconnect,child_node_new_connect'",
 		"location":                     r.Region,
 		"primary_visibility_consensus": true,

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -144,7 +144,7 @@ func (r *RepMgr) setDefaults() {
 		"use_replication_slots":        "yes",
 		"promote_command":              fmt.Sprintf("'repmgr standby promote -f %s --log-to-file'", r.ConfigPath),
 		"follow_command":               fmt.Sprintf("'repmgr standby follow -f %s --log-to-file --upstream-node-id=%%n'", r.ConfigPath),
-		"event_notification_command":   fmt.Sprintf("'/usr/local/bin/event_handler -node-id %%n -event %%e -success %%s -details \"%%d\" -new-node-id \\'%%p\\''"),
+		"event_notification_command":   fmt.Sprintf("'/usr/local/bin/event_handler -node-id %%n -event %%e -success %%s -details \"%%d\""),
 		"event_notifications":          "'child_node_disconnect,child_node_reconnect,child_node_new_connect'",
 		"location":                     r.Region,
 		"primary_visibility_consensus": true,


### PR DESCRIPTION
This was preventing the event handler from working properly.

```
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  | flag provided but not defined: -new-node-id
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  | Usage of /usr/local/bin/event_handler:
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  |   -details string
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  |     	details
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  |   -event string
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  |     	event type
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  |   -node-id int
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  |     	the node id
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  |   -success string
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  |     	success (1) failure (0)
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  | [2023-02-16 19:26:27] [WARNING] unable to execute event notification command
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  | [2023-02-16 19:26:27] [DETAIL] parsed event notification command was:
2023-02-16T19:26:27Z app[9185956b425e83] lax [info]repmgrd  |   /usr/local/bin/event_handler -node-id 1537531293 -event child_node_disconnect -success 1 -details "standby node \"fdaa:0:2e26:a7b:7d18:391b:2e60:2\" (ID: 332095990) has disconnected" -new-node-id ''
```