### PR TITLE
Remove required consul call

### DIFF
--- a/internal/flypg/node.go
+++ b/internal/flypg/node.go
@@ -225,7 +225,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 	}
 
 	if registered {
-		// Existing members
+		// Existing member
 		repConn, err := n.RepMgr.NewLocalConnection(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to establish connection to local repmgr: %s", err)

--- a/internal/flypg/registration.go
+++ b/internal/flypg/registration.go
@@ -50,7 +50,7 @@ func isRegistered(ctx context.Context, conn *pgx.Conn, n *Node) (bool, error) {
 		return false, fmt.Errorf("failed to resolve member role: %s", err)
 	}
 
-	// Does it matter if it's active or not?
+	// If we are active, issue registration certificate
 	if member.Active {
 		if err := issueRegistrationCertificate(); err != nil {
 			fmt.Println("failed to issue registration certificate.")

--- a/internal/flypg/registration.go
+++ b/internal/flypg/registration.go
@@ -11,12 +11,12 @@ import (
 )
 
 func isRegistered(ctx context.Context, conn *pgx.Conn, n *Node) (bool, error) {
-	// Short-circuit if we are holding a the registration certificate
+	// Short-circuit if we are holding a certificate
 	if hasRegistrationCertificate() {
 		return true, nil
 	}
 
-	// This is for backwards compatibility.
+	// Below is for backwards compatibility
 	databases, err := admin.ListDatabases(ctx, conn)
 	if err != nil {
 		return false, err
@@ -59,18 +59,7 @@ func isRegistered(ctx context.Context, conn *pgx.Conn, n *Node) (bool, error) {
 }
 
 func issueRegistrationCertificate() error {
-	if err := os.WriteFile("/data/.registrationCert", []byte(""), 0600); err != nil {
-		return err
-	}
-	return nil
-}
-
-func removeRegistrationCertificate() error {
-	if err := os.Remove("/data/.registrationCert"); err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile("/data/.registrationCert", []byte(""), 0600)
 }
 
 func hasRegistrationCertificate() bool {

--- a/internal/flypg/registration.go
+++ b/internal/flypg/registration.go
@@ -1,0 +1,83 @@
+package flypg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/fly-apps/postgres-flex/internal/flypg/admin"
+	"github.com/jackc/pgx/v5"
+)
+
+func isRegistered(ctx context.Context, conn *pgx.Conn, n *Node) (bool, error) {
+	// Short-circuit if we are holding a the registration certificate
+	if hasRegistrationCertificate() {
+		return true, nil
+	}
+
+	// This is for backwards compatibility.
+	databases, err := admin.ListDatabases(ctx, conn)
+	if err != nil {
+		return false, err
+	}
+
+	repmgrExists := false
+	for _, db := range databases {
+		if db.Name == n.RepMgr.DatabaseName {
+			repmgrExists = true
+			break
+		}
+	}
+
+	if !repmgrExists {
+		return false, nil
+	}
+
+	repConn, err := n.RepMgr.NewLocalConnection(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = repConn.Close(ctx) }()
+
+	member, err := n.RepMgr.Member(ctx, conn)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to resolve member role: %s", err)
+	}
+
+	if member.Active {
+		if err := issueRegistrationCertificate(); err != nil {
+			fmt.Println("failed to issue registration certificate.")
+			return true, nil
+		}
+	}
+
+	return true, nil
+}
+
+func issueRegistrationCertificate() error {
+	if err := os.WriteFile("/data/.registrationCert", []byte(""), 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func removeRegistrationCertificate() error {
+	if err := os.Remove("/data/.registrationCert"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func hasRegistrationCertificate() bool {
+	if _, err := os.Stat("/data/.registrationCert"); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/flypg/registration.go
+++ b/internal/flypg/registration.go
@@ -10,6 +10,8 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+const rCertPath = "/data/.registration"
+
 func isRegistered(ctx context.Context, conn *pgx.Conn, n *Node) (bool, error) {
 	// Short-circuit if we are holding a certificate
 	if hasRegistrationCertificate() {
@@ -48,6 +50,7 @@ func isRegistered(ctx context.Context, conn *pgx.Conn, n *Node) (bool, error) {
 		return false, fmt.Errorf("failed to resolve member role: %s", err)
 	}
 
+	// Does it matter if it's active or not?
 	if member.Active {
 		if err := issueRegistrationCertificate(); err != nil {
 			fmt.Println("failed to issue registration certificate.")
@@ -59,11 +62,11 @@ func isRegistered(ctx context.Context, conn *pgx.Conn, n *Node) (bool, error) {
 }
 
 func issueRegistrationCertificate() error {
-	return os.WriteFile("/data/.registrationCert", []byte(""), 0600)
+	return os.WriteFile(rCertPath, []byte(""), 0600)
 }
 
 func hasRegistrationCertificate() bool {
-	if _, err := os.Stat("/data/.registrationCert"); err != nil {
+	if _, err := os.Stat(rCertPath); err != nil {
 		if os.IsNotExist(err) {
 			return false
 		}

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -391,7 +391,7 @@ func (r *RepMgr) ResolveMemberOverDNS(ctx context.Context) (*Member, error) {
 
 		conn, err := r.NewRemoteConnection(ctx, ip.String())
 		if err != nil {
-			fmt.Printf("failed to resolve %s\n", ip.String())
+			fmt.Printf("failed to resolve %s: %s\n", ip.String(), err)
 			continue
 		}
 		defer func() { _ = conn.Close(ctx) }()


### PR DESCRIPTION
This will ensure cluster members can be restarted, upgraded, etc. without hitting Consul.