### PR TITLE
Remove log

### DIFF
--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -391,7 +391,6 @@ func (r *RepMgr) ResolveMemberOverDNS(ctx context.Context) (*Member, error) {
 
 		conn, err := r.NewRemoteConnection(ctx, ip.String())
 		if err != nil {
-			fmt.Printf("failed to resolve %s: %s\n", ip.String(), err)
 			continue
 		}
 		defer func() { _ = conn.Close(ctx) }()


### PR DESCRIPTION
This log is expected in many situations.  Removing it and we will only error if we can't find a cloneable target. 