### PR TITLE
Use `flypgadmin` user for internal connections

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -67,7 +67,7 @@ func localConnection(ctx context.Context, database string) (*pgx.Conn, error) {
 		return nil, err
 	}
 
-	pg, err := node.NewLocalConnection(ctx, database)
+	pg, err := node.NewLocalConnection(ctx, database, node.OperatorCredentials)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/flycheck/pg.go
+++ b/internal/flycheck/pg.go
@@ -19,7 +19,7 @@ func CheckPostgreSQL(ctx context.Context, checks *check.CheckSuite) (*check.Chec
 		return checks, fmt.Errorf("failed to initialize node: %s", err)
 	}
 
-	localConn, err := node.NewLocalConnection(ctx, "postgres")
+	localConn, err := node.NewLocalConnection(ctx, "postgres", node.SUCredentials)
 	if err != nil {
 		return checks, fmt.Errorf("failed to connect with local node: %s", err)
 	}


### PR DESCRIPTION
Right now, this only applies to the PG check.  However, it's important that users are able to differentiate between their own connections and our internal connections. 