### PR TITLE
Threadsafe logging

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"syscall"
 	"time"
@@ -12,6 +13,8 @@ import (
 )
 
 func main() {
+	log.SetFlags(0)
+
 	requiredPasswords := []string{"SU_PASSWORD", "OPERATOR_PASSWORD", "REPL_PASSWORD"}
 	for _, str := range requiredPasswords {
 		if _, exists := os.LookupEnv(str); !exists {

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -35,7 +35,6 @@ func status(err error) int {
 	var pgErr *pgconn.PgError
 
 	if errors.As(err, &pgErr) {
-		// fmt.Printf("%s: %s\n", pgErr.Code, pgErr.Message)
 		switch pgErr.Code {
 		case "42710": // unique violation
 			return http.StatusConflict

--- a/internal/flycheck/pg.go
+++ b/internal/flycheck/pg.go
@@ -3,6 +3,7 @@ package flycheck
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/fly-apps/postgres-flex/internal/flypg"
 	"github.com/jackc/pgx/v5"
@@ -69,9 +70,9 @@ func diskCapacityCheck(ctx context.Context, node *flypg.Node) (string, error) {
 		// If the read-only lock has already been set, we can assume that we've already
 		// broadcasted.
 		if !flypg.ReadOnlyLockExists() {
-			fmt.Println("Broadcasting readonly change to registered standbys")
+			log.Println("[WARN] Broadcasting readonly change to registered standbys")
 			if err := flypg.BroadcastReadonlyChange(ctx, node, true); err != nil {
-				fmt.Printf("errors with enable readonly broadcast: %s\n", err)
+				log.Printf("[ERROR] Failed to enable readonly: %s\n", err)
 			}
 		}
 
@@ -81,7 +82,7 @@ func diskCapacityCheck(ctx context.Context, node *flypg.Node) (string, error) {
 	// Don't attempt to disable readonly if there's a zombie.lock
 	if !flypg.ZombieLockExists() && flypg.ReadOnlyLockExists() {
 		if err := flypg.BroadcastReadonlyChange(ctx, node, false); err != nil {
-			fmt.Printf("errors with disable readonly broadcast: %s\n", err)
+			log.Printf("[ERROR] Failed to disable readonly: %s\n", err)
 		}
 	}
 

--- a/internal/flypg/node.go
+++ b/internal/flypg/node.go
@@ -252,13 +252,13 @@ func (n *Node) PostInit(ctx context.Context) error {
 			// Verify cluster state to ensure we are the actual primary and not a zombie.
 			primary, err := PerformScreening(ctx, conn, n)
 			if errors.Is(err, ErrZombieDiagnosisUndecided) {
-				log.Println("[WARN] Unable to confirm that we are the true primary!")
+				log.Println("[ERROR] Unable to confirm that we are the true primary!")
 				// Turn member read-only
 				if err := Quarantine(ctx, n, primary); err != nil {
 					return fmt.Errorf("failed to quarantine failed primary: %s", err)
 				}
 			} else if errors.Is(err, ErrZombieDiscovered) {
-				log.Printf("[WARN] The majority of registered members agree that '%s' is the real primary.\n", primary)
+				log.Printf("[ERROR] The majority of registered members agree that '%s' is the real primary.\n", primary)
 				// Turn member read-only
 				if err := Quarantine(ctx, n, primary); err != nil {
 					return fmt.Errorf("failed to quarantine failed primary: %s", err)

--- a/internal/flypg/node.go
+++ b/internal/flypg/node.go
@@ -313,7 +313,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 
 		if !clusterInitialized {
 			// Configure as primary
-			log.Println("[INFO] Registering primary")
+			log.Println("Registering primary")
 
 			// Verify we reside within the clusters primary region
 			if !n.RepMgr.eligiblePrimary() {
@@ -350,7 +350,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 			}
 		} else {
 			// Configure as standby
-			log.Println("[INFO] Registering standby")
+			log.Println("Registering standby")
 			if err := n.RepMgr.registerStandby(); err != nil {
 				return fmt.Errorf("failed to register new standby: %s", err)
 			}

--- a/internal/flypg/node.go
+++ b/internal/flypg/node.go
@@ -164,7 +164,7 @@ func (n *Node) Init(ctx context.Context) error {
 		}
 
 		if !clusterInitialized {
-			log.Println("[INFO] Provisioning primary")
+			log.Println("Provisioning primary")
 			// TODO - This should probably run on boot in case the password changes.
 			if err := n.PGConfig.writePasswordFile(n.OperatorCredentials.Password); err != nil {
 				return fmt.Errorf("failed to write pg password file: %s", err)
@@ -174,7 +174,7 @@ func (n *Node) Init(ctx context.Context) error {
 				return fmt.Errorf("failed to initialize postgres %s", err)
 			}
 		} else {
-			log.Println("[INFO] Provisioning standby")
+			log.Println("Provisioning standby")
 			cloneTarget, err := n.RepMgr.ResolveMemberOverDNS(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to resolve member over dns: %s", err)

--- a/internal/flypg/pg.go
+++ b/internal/flypg/pg.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -177,7 +178,7 @@ func (c *PGConfig) SetDefaults() error {
 func (c *PGConfig) RuntimeApply(ctx context.Context, conn *pgx.Conn) error {
 	for key, value := range c.userConfig {
 		if err := admin.SetConfigurationSetting(ctx, conn, key, value); err != nil {
-			fmt.Printf("failed to set configuration setting %s -> %s: %s", key, value, err)
+			log.Printf("[WARN] Failed to set configuration setting %s -> %s: %s", key, value, err)
 		}
 	}
 
@@ -230,8 +231,8 @@ func (c *PGConfig) initialize(store *state.Store) error {
 	}
 
 	if err := SyncUserConfig(c, store); err != nil {
-		fmt.Printf("WARNING: Failed to sync user config from consul for postgres: %s\n", err.Error())
-		fmt.Println("       This may cause this node to behave unexpectedly")
+		log.Printf("[WARN] Failed to sync user config from consul for postgres: %s\n", err.Error())
+		log.Println("[WARN] This may cause this node to behave unexpectedly")
 		if err := writeInternalConfigFile(c); err != nil {
 			return fmt.Errorf("failed to write pg config files: %s", err)
 		}

--- a/internal/flypg/registration.go
+++ b/internal/flypg/registration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/fly-apps/postgres-flex/internal/flypg/admin"
@@ -53,7 +54,7 @@ func isRegistered(ctx context.Context, conn *pgx.Conn, n *Node) (bool, error) {
 	// If we are active, issue registration certificate
 	if member.Active {
 		if err := issueRegistrationCert(); err != nil {
-			fmt.Println("failed to issue registration certificate.")
+			log.Println("[WARN] Failed to issue registration certificate.")
 			return true, nil
 		}
 	}

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"log"
 	"math"
 	"math/big"
 	"net"
@@ -235,7 +236,7 @@ func (r *RepMgr) rejoinCluster(hostname string) error {
 		r.DatabaseName,
 	)
 
-	fmt.Println(cmdStr)
+	log.Println("[INFO] " + cmdStr)
 	_, err := utils.RunCommand(cmdStr, "postgres")
 
 	return err
@@ -245,7 +246,7 @@ func (r *RepMgr) registerStandby() error {
 	// Force re-registry to ensure the standby picks up any new configuration changes.
 	cmdStr := fmt.Sprintf("repmgr -f %s standby register -F", r.ConfigPath)
 	if _, err := utils.RunCommand(cmdStr, "postgres"); err != nil {
-		fmt.Printf("failed to register standby: %s", err)
+		return err
 	}
 
 	return nil
@@ -254,7 +255,7 @@ func (r *RepMgr) registerStandby() error {
 func (r *RepMgr) unregisterStandby(id int) error {
 	cmdStr := fmt.Sprintf("repmgr standby unregister -f %s --node-id=%d", r.ConfigPath, id)
 	if _, err := utils.RunCommand(cmdStr, "postgres"); err != nil {
-		fmt.Printf("failed to unregister standby: %s", err)
+		return err
 	}
 
 	return nil
@@ -273,7 +274,7 @@ func (r *RepMgr) clonePrimary(ipStr string) error {
 		r.Credentials.Username,
 		r.ConfigPath)
 
-	fmt.Println(cmdStr)
+	log.Println("[INFO] " + cmdStr)
 	if _, err := utils.RunCommand(cmdStr, "postgres"); err != nil {
 		return fmt.Errorf("failed to clone primary: %s", err)
 	}
@@ -397,7 +398,6 @@ func (r *RepMgr) ResolveMemberOverDNS(ctx context.Context) (*Member, error) {
 
 		member, err := r.MemberByHostname(ctx, conn, ip.String())
 		if err != nil {
-			fmt.Printf("failed to resolve role from %s", ip.String())
 			continue
 		}
 

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -236,7 +236,7 @@ func (r *RepMgr) rejoinCluster(hostname string) error {
 		r.DatabaseName,
 	)
 
-	log.Println("[INFO] " + cmdStr)
+	log.Println(cmdStr)
 	_, err := utils.RunCommand(cmdStr, "postgres")
 
 	return err
@@ -274,7 +274,7 @@ func (r *RepMgr) clonePrimary(ipStr string) error {
 		r.Credentials.Username,
 		r.ConfigPath)
 
-	log.Println("[INFO] " + cmdStr)
+	log.Println(cmdStr)
 	if _, err := utils.RunCommand(cmdStr, "postgres"); err != nil {
 		return fmt.Errorf("failed to clone primary: %s", err)
 	}

--- a/internal/flypg/restore.go
+++ b/internal/flypg/restore.go
@@ -52,7 +52,7 @@ func Restore(ctx context.Context, node *Node) error {
 
 	go func() {
 		if err := svisor.Run(); err != nil {
-			log.Printf("failed to boot postgres in the background: %s", err)
+			log.Printf("[ERROR] failed to boot postgres in the background: %s", err)
 		}
 	}()
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -3,6 +3,7 @@ package supervisor
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -112,7 +113,7 @@ func (h *Supervisor) waitForTimeoutOrInterrupt() {
 func (h *Supervisor) waitForExit(ctx context.Context) {
 	<-ctx.Done()
 
-	fmt.Println("supervisor stopping")
+	log.Println("Supervisor stopping")
 
 	for _, proc := range h.procs {
 		go proc.Interrupt()
@@ -159,7 +160,7 @@ func (h *Supervisor) StopOnSignal(sigs ...os.Signal) {
 
 	go func() {
 		for sig := range sigch {
-			fmt.Printf("Got %s, stopping\n", sig)
+			log.Printf("Got %s, stopping\n", sig)
 			h.Stop()
 		}
 	}()


### PR DESCRIPTION
Notable changes:

* Use the log package over fmt.Print...
* Add `[WARN]` and `[ERROR]` tags to make it easier to troubleshoot and comb through logs.  