### PR TITLE
Move event processing to the admin api

### DIFF
--- a/cmd/event_handler/main.go
+++ b/cmd/event_handler/main.go
@@ -1,99 +1,53 @@
 package main
 
 import (
-	"context"
-	"errors"
+	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
-	"os"
+	"net/http"
 
+	"github.com/fly-apps/postgres-flex/internal/api"
 	"github.com/fly-apps/postgres-flex/internal/flypg"
-	"github.com/jackc/pgx/v5"
 )
 
-const eventLogFile = "/data/event.log"
-
 func main() {
-	ctx := context.Background()
-
-	if err := processEvent(ctx); err != nil {
-		log.Println(err)
-		os.Exit(1)
-	}
-}
-
-func processEvent(ctx context.Context) error {
 	event := flag.String("event", "", "event type")
 	nodeID := flag.Int("node-id", 0, "the node id")
 	success := flag.String("success", "", "success (1) failure (0)")
 	details := flag.String("details", "", "details")
 	flag.Parse()
 
-	logFile, err := os.OpenFile(eventLogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to open event log: %s", err)
+	succ := true
+	if *success == "0" {
+		succ = false
 	}
-	defer func() { _ = logFile.Close() }()
 
-	log.SetOutput(logFile)
-	log.Printf("event: %s, node: %d, success: %s, details: %s\n", *event, *nodeID, *success, *details)
+	req := api.EventRequest{
+		Name:    *event,
+		NodeID:  *nodeID,
+		Success: succ,
+		Details: *details,
+	}
 
 	node, err := flypg.NewNode()
 	if err != nil {
-		return fmt.Errorf("failed to initialize node: %s", err)
+		log.Fatalln(err)
 	}
 
-	switch *event {
-	case "child_node_disconnect", "child_node_reconnect", "child_node_new_connect":
-		conn, err := node.RepMgr.NewLocalConnection(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to open local connection: %s", err)
-		}
-		defer func() { _ = conn.Close(ctx) }()
-
-		member, err := node.RepMgr.Member(ctx, conn)
-		if err != nil {
-			return fmt.Errorf("failed to resolve member: %s", err)
-		}
-
-		if member.Role != flypg.PrimaryRoleName {
-			// We should never get here.
-			log.Println("skipping since we are not the primary")
-			return nil
-		}
-
-		if err := evaluateClusterState(ctx, conn, node); err != nil {
-			return fmt.Errorf("failed to evaluate cluster state: %s", err)
-		}
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
-	return logFile.Sync()
-}
-
-func evaluateClusterState(ctx context.Context, conn *pgx.Conn, node *flypg.Node) error {
-	primary, err := flypg.PerformScreening(ctx, conn, node)
-	if errors.Is(err, flypg.ErrZombieDiagnosisUndecided) || errors.Is(err, flypg.ErrZombieDiscovered) {
-		if err := flypg.Quarantine(ctx, node, primary); err != nil {
-			return fmt.Errorf("failed to quarantine failed primary: %s", err)
-		}
-		return fmt.Errorf("primary has been quarantined: %s", err)
-	} else if err != nil {
-		return fmt.Errorf("failed to run zombie diagnosis: %s", err)
+	endpoint := fmt.Sprintf("http://[%s]:5500/commands/events/process", node.PrivateIP)
+	resp, err := http.Post(endpoint, "application/json", bytes.NewReader(reqBytes))
+	if err != nil {
+		log.Fatalln(err)
 	}
 
-	// Clear zombie lock if it exists
-	if flypg.ZombieLockExists() {
-		log.Println("Clearing zombie lock and re-enabling read/write")
-		if err := flypg.RemoveZombieLock(); err != nil {
-			return fmt.Errorf("failed to remove zombie lock: %s", err)
-		}
-
-		log.Println("Broadcasting readonly state change")
-		if err := flypg.BroadcastReadonlyChange(ctx, node, false); err != nil {
-			log.Printf("failed to disable readonly: %s", err)
-		}
+	if err := resp.Body.Close(); err != nil {
+		log.Fatalln(err)
 	}
-
-	return nil
 }

--- a/cmd/event_handler/main.go
+++ b/cmd/event_handler/main.go
@@ -31,12 +31,12 @@ func main() {
 		Details: *details,
 	}
 
-	node, err := flypg.NewNode()
+	reqBytes, err := json.Marshal(req)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	reqBytes, err := json.Marshal(req)
+	node, err := flypg.NewNode()
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -21,6 +21,8 @@ var (
 func main() {
 	ctx := context.Background()
 
+	log.SetFlags(0)
+
 	node, err := flypg.NewNode()
 	if err != nil {
 		panic(fmt.Sprintf("failed to reference node: %s\n", err))

--- a/internal/api/handle_event.go
+++ b/internal/api/handle_event.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/fly-apps/postgres-flex/internal/flypg"
+	"github.com/jackc/pgx/v5"
+)
+
+type EventRequest struct {
+	Name    string `json:"name"`
+	NodeID  int    `json:"nodeID"`
+	Success bool   `json:"success"`
+	Details string `json:"details"`
+}
+
+func handleEvent(w http.ResponseWriter, r *http.Request) {
+	var event EventRequest
+	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+		log.Printf("[ERROR] Failed to decode event request: %s\n", err)
+		renderErr(w, err)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	if !event.Success {
+		errMsg := fmt.Sprintf("[ERROR] event %s was non-successful: %s", event.Name, event.Details)
+		log.Println(errMsg)
+		renderErr(w, errors.New(errMsg))
+		return
+	}
+
+	if err := processEvent(r.Context(), event); err != nil {
+		log.Printf("[ERROR] failed to process event: %s\n", err)
+		renderErr(w, err)
+		return
+	}
+}
+
+func processEvent(ctx context.Context, event EventRequest) error {
+	log.Printf("Processing event: %s\n", event.Name)
+
+	node, err := flypg.NewNode()
+	if err != nil {
+		return fmt.Errorf("failed to initialize node: %s", err)
+	}
+
+	switch event.Name {
+	case "child_node_disconnect", "child_node_reconnect", "child_node_new_connect":
+		conn, err := node.RepMgr.NewLocalConnection(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to open local connection: %s", err)
+		}
+		defer func() { _ = conn.Close(ctx) }()
+
+		member, err := node.RepMgr.Member(ctx, conn)
+		if err != nil {
+			return fmt.Errorf("failed to resolve member: %s", err)
+		}
+
+		if member.Role != flypg.PrimaryRoleName {
+			// We should never get here.
+			return nil
+		}
+
+		if err := evaluateClusterState(ctx, conn, node); err != nil {
+			return fmt.Errorf("failed to evaluate cluster state: %s", err)
+		}
+	}
+
+	return nil
+}
+
+// TODO Move this into zombie.go
+func evaluateClusterState(ctx context.Context, conn *pgx.Conn, node *flypg.Node) error {
+	primary, err := flypg.PerformScreening(ctx, conn, node)
+	if errors.Is(err, flypg.ErrZombieDiagnosisUndecided) || errors.Is(err, flypg.ErrZombieDiscovered) {
+		if err := flypg.Quarantine(ctx, node, primary); err != nil {
+			return fmt.Errorf("failed to quarantine failed primary: %s", err)
+		}
+		log.Println("[WARN] Primary is going read-only to protect against potential split-brain")
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to run zombie diagnosis: %s", err)
+	}
+
+	// Clear zombie lock if it exists
+	if flypg.ZombieLockExists() {
+		log.Println("Quorom has been reached. Disabling read-only mode.")
+		if err := flypg.RemoveZombieLock(); err != nil {
+			return fmt.Errorf("failed to remove zombie lock file: %s", err)
+		}
+
+		if err := flypg.BroadcastReadonlyChange(ctx, node, false); err != nil {
+			log.Printf("failed to disable readonly: %s", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -15,6 +16,8 @@ import (
 const Port = 5500
 
 func StartHttpServer() error {
+	log.SetFlags(0)
+
 	r := chi.NewMux()
 	r.Mount("/flycheck", flycheck.Handler())
 	r.Mount("/commands", Handler())
@@ -30,6 +33,9 @@ func StartHttpServer() error {
 
 func Handler() http.Handler {
 	r := chi.NewRouter()
+	r.Route("/events", func(r chi.Router) {
+		r.Post("/process", handleEvent)
+	})
 
 	r.Route("/users", func(r chi.Router) {
 		r.Get("/{name}", handleGetUser)


### PR DESCRIPTION
This delegates the actual event processing to the admin api, which will ensure event logs are visible to the end-user.

<img width="1139" alt="Screenshot 2023-03-01 at 3 39 50 PM" src="https://user-images.githubusercontent.com/423038/222271053-71f21898-dd7f-43da-9380-d87fef2469f8.png">

Addresses: https://github.com/fly-apps/postgres-flex/issues/69
