### PR TITLE
Speed up provisions by using fast checkpoints

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -12,7 +12,7 @@ import (
 var (
 	deadMemberMonitorFrequency       = time.Hour * 1
 	replicationStateMonitorFrequency = time.Hour * 1
-	clusterStateMonitorFrequency     = time.Minute * 15
+	clusterStateMonitorFrequency     = time.Minute * 10
 
 	defaultDeadMemberRemovalThreshold   = time.Hour * 12
 	defaultInactiveSlotRemovalThreshold = time.Hour * 12

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -267,7 +267,7 @@ func (r *RepMgr) clonePrimary(ipStr string) error {
 		return fmt.Errorf("failed to create pg directory: %s", err)
 	}
 
-	cmdStr = fmt.Sprintf("repmgr -h %s -p %d -d %s -U %s -f %s standby clone -F",
+	cmdStr = fmt.Sprintf("repmgr -h %s -p %d -d %s -U %s -f %s standby clone -c -F",
 		ipStr,
 		r.Port,
 		r.DatabaseName,


### PR DESCRIPTION
This shaves close to a minute and a half off provision times of a 3 node cluster, which is pretty significant.  However, there are some trade-offs to consider:

> The checkpoint requirement of flushing all dirty data pages to disk can cause a significant I/O load. For this reason, checkpoint activity is throttled so that I/O begins at checkpoint start and completes before the next checkpoint is due to start; this minimizes performance degradation during checkpoints.

Basically, there's no need to consider I/O load and any performance implications on provision.  However, this setting is probably not a great for users horizontally scaling their production setup that's already under high load.  

We should make this configurable so users can disable it in the event they find themselves adding/removing replicas often enough to care. 