### PR TITLE
Validate Postres config

### DIFF
--- a/internal/api/handle_admin.go
+++ b/internal/api/handle_admin.go
@@ -150,20 +150,8 @@ func handleUpdatePostgresSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for k, v := range requestedChanges {
-		exists, err := admin.SettingExists(r.Context(), conn, k)
-		if err != nil {
-			renderErr(w, err)
-			return
-		}
-		if !exists {
-			renderErr(w, fmt.Errorf("invalid config option: %s", k))
-			return
-		}
-		cfg[k] = v
-	}
-
-	requestedChanges, err = node.PGConfig.Validate(cfg)
+	// Logistical PG setting validations.
+	requestedChanges, err = node.PGConfig.Validate(r.Context(), conn, requestedChanges)
 	if err != nil {
 		renderErr(w, err)
 		return

--- a/internal/api/handle_admin.go
+++ b/internal/api/handle_admin.go
@@ -157,6 +157,10 @@ func handleUpdatePostgresSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	for k, v := range requestedChanges {
+		cfg[k] = v
+	}
+
 	node.PGConfig.SetUserConfig(cfg)
 
 	var requiresRestart []string

--- a/internal/api/handle_admin.go
+++ b/internal/api/handle_admin.go
@@ -163,7 +163,7 @@ func handleUpdatePostgresSettings(w http.ResponseWriter, r *http.Request) {
 		cfg[k] = v
 	}
 
-	requestedChanges, err = node.PGConfig.ValidateConfig(requestedChanges)
+	requestedChanges, err = node.PGConfig.Validate(cfg)
 	if err != nil {
 		renderErr(w, err)
 		return

--- a/internal/api/handle_admin.go
+++ b/internal/api/handle_admin.go
@@ -154,12 +154,19 @@ func handleUpdatePostgresSettings(w http.ResponseWriter, r *http.Request) {
 		exists, err := admin.SettingExists(r.Context(), conn, k)
 		if err != nil {
 			renderErr(w, err)
+			return
 		}
 		if !exists {
 			renderErr(w, fmt.Errorf("invalid config option: %s", k))
 			return
 		}
 		cfg[k] = v
+	}
+
+	requestedChanges, err = node.PGConfig.ValidateConfig(requestedChanges)
+	if err != nil {
+		renderErr(w, err)
+		return
 	}
 
 	node.PGConfig.SetUserConfig(cfg)

--- a/internal/flypg/admin/admin.go
+++ b/internal/flypg/admin/admin.go
@@ -392,8 +392,7 @@ func ValidatePGSettings(ctx context.Context, conn *pgx.Conn, requested map[strin
 
 		// Verify specified extensions are installed
 		if k == "shared_preload_libraries" {
-			extensions := v.(string)
-			extensions = strings.Trim(v.(string), "'")
+			extensions := strings.Trim(v.(string), "'")
 			extSlice := strings.Split(extensions, ",")
 			for _, e := range extSlice {
 				available, err := ExtensionAvailable(ctx, conn, e)

--- a/internal/flypg/admin/admin.go
+++ b/internal/flypg/admin/admin.go
@@ -337,6 +337,15 @@ func SettingExists(ctx context.Context, pg *pgx.Conn, setting string) (bool, err
 	return out, nil
 }
 
+func ExtensionAvailable(ctx context.Context, pg *pgx.Conn, extension string) (bool, error) {
+	sql := fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name='%s')", extension)
+	var out bool
+	if err := pg.QueryRow(ctx, sql).Scan(&out); err != nil {
+		return false, err
+	}
+	return out, nil
+}
+
 func SettingRequiresRestart(ctx context.Context, pg *pgx.Conn, setting string) (bool, error) {
 	sql := fmt.Sprintf("SELECT pending_restart FROM pg_settings WHERE name='%s'", setting)
 	row := pg.QueryRow(ctx, sql)
@@ -369,4 +378,35 @@ func GetSetting(ctx context.Context, pg *pgx.Conn, setting string) (*PGSetting, 
 		return nil, err
 	}
 	return &out, nil
+}
+
+func ValidatePGSettings(ctx context.Context, conn *pgx.Conn, requested map[string]interface{}) error {
+	for k, v := range requested {
+		exists, err := SettingExists(ctx, conn, k)
+		if err != nil {
+			return fmt.Errorf("failed to verify setting: %s", err)
+		}
+		if !exists {
+			return fmt.Errorf("setting %v is not a valid config option", k)
+		}
+
+		// Verify specified extensions are installed
+		if k == "shared_preload_libraries" {
+			extensions := v.(string)
+			extensions = strings.Trim(v.(string), "'")
+			extSlice := strings.Split(extensions, ",")
+			for _, e := range extSlice {
+				available, err := ExtensionAvailable(ctx, conn, e)
+				if err != nil {
+					return fmt.Errorf("failed to verify pg extension %s: %s", e, err)
+				}
+
+				if !available {
+					return fmt.Errorf("extension %s has not been installed within this image", e)
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/flypg/pg.go
+++ b/internal/flypg/pg.go
@@ -274,7 +274,7 @@ func (c *PGConfig) writePasswordFile(pwd string) error {
 	return nil
 }
 
-func (c *PGConfig) ValidateConfig(requested ConfigMap) (ConfigMap, error) {
+func (c *PGConfig) Validate(requested ConfigMap) (ConfigMap, error) {
 	current, err := c.CurrentConfig()
 	if err != nil {
 		return requested, fmt.Errorf("failed to resolve current config: %s", err)
@@ -288,7 +288,7 @@ func (c *PGConfig) ValidateConfig(requested ConfigMap) (ConfigMap, error) {
 		val = strings.TrimSpace(val)
 
 		if val == "" {
-			return requested, errors.New("`shared_preload_libraries` must contain the repmgr extension")
+			return requested, errors.New("`shared_preload_libraries` must contain the `repmgr` extension")
 		}
 
 		repmgrPresent := false
@@ -302,7 +302,7 @@ func (c *PGConfig) ValidateConfig(requested ConfigMap) (ConfigMap, error) {
 		}
 
 		if !repmgrPresent {
-			return requested, errors.New("`shared_preload_libraries` must contain the repmgr extension")
+			return requested, errors.New("`shared_preload_libraries` must contain the `repmgr` extension")
 		}
 
 		requested["shared_preload_libraries"] = fmt.Sprintf("'%s'", val)

--- a/internal/flypg/pg.go
+++ b/internal/flypg/pg.go
@@ -279,6 +279,10 @@ func (c *PGConfig) Validate(ctx context.Context, conn *pgx.Conn, requested Confi
 		return requested, err
 	}
 
+	return c.validateCompatibility(requested)
+}
+
+func (c *PGConfig) validateCompatibility(requested ConfigMap) (ConfigMap, error) {
 	current, err := c.CurrentConfig()
 	if err != nil {
 		return requested, fmt.Errorf("failed to resolve current config: %s", err)

--- a/internal/flypg/pg.go
+++ b/internal/flypg/pg.go
@@ -3,6 +3,7 @@ package flypg
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -167,7 +168,7 @@ func (c *PGConfig) SetDefaults() error {
 		"wal_level":                "replica",
 		"wal_log_hints":            true,
 		"hot_standby":              true,
-		"archive_mode":             true,
+		"archive_mode":             "on",
 		"archive_command":          "'/bin/true'",
 		"shared_preload_libraries": fmt.Sprintf("'%s'", strings.Join(sharedPreloadLibraries, ",")),
 	}
@@ -271,6 +272,65 @@ func (c *PGConfig) writePasswordFile(pwd string) error {
 	}
 
 	return nil
+}
+
+func (c *PGConfig) ValidateConfig(requested ConfigMap) (ConfigMap, error) {
+	current, err := c.CurrentConfig()
+	if err != nil {
+		return requested, fmt.Errorf("failed to resolve current config: %s", err)
+	}
+
+	// Shared preload libraries
+	if v, ok := requested["shared_preload_libraries"]; ok {
+		val := v.(string)
+		// Strip off any single quotes that my have been added
+		val = strings.Trim(val, "'")
+		val = strings.TrimSpace(val)
+
+		if val == "" {
+			return requested, errors.New("`shared_preload_libraries` must contain the repmgr extension")
+		}
+
+		repmgrPresent := false
+
+		entries := strings.Split(val, ",")
+		for _, entry := range entries {
+			if entry == "repmgr" {
+				repmgrPresent = true
+				break
+			}
+		}
+
+		if !repmgrPresent {
+			return requested, errors.New("`shared_preload_libraries` must contain the repmgr extension")
+		}
+
+		requested["shared_preload_libraries"] = fmt.Sprintf("'%s'", val)
+	}
+
+	// Wal-level
+	if v, ok := requested["wal_level"]; ok {
+		value := v.(string)
+
+		if value == "minimal" {
+			valid := false
+			if val, ok := requested["archive_mode"]; ok {
+				if val == "off" {
+					valid = true
+				}
+			}
+
+			if !valid && current["archive_mode"] == "off" {
+				valid = true
+			}
+
+			if !valid {
+				return requested, errors.New("archive_mode must be set to `off` before wal_level can be set to `minimal`")
+			}
+		}
+	}
+
+	return requested, nil
 }
 
 type HBAEntry struct {

--- a/internal/flypg/pg_test.go
+++ b/internal/flypg/pg_test.go
@@ -285,7 +285,7 @@ func TestValidateConfiguration(t *testing.T) {
 			"shared_preload_libraries": "repmgr",
 		}
 
-		conf, err := pgConf.ValidateConfig(valid)
+		conf, err := pgConf.Validate(valid)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -298,7 +298,7 @@ func TestValidateConfiguration(t *testing.T) {
 			"shared_preload_libraries": "'repmgr'",
 		}
 
-		conf, err = pgConf.ValidateConfig(valid)
+		conf, err = pgConf.Validate(valid)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -311,10 +311,14 @@ func TestValidateConfiguration(t *testing.T) {
 			"shared_preload_libraries": "repmgr,timescaledb",
 		}
 
-		conf, err = pgConf.ValidateConfig(valid)
+		conf, err = pgConf.Validate(valid)
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		pgConf.SetUserConfig(conf)
+
+		fmt.Printf("%+v\n", pgConf.userConfig)
 
 		if conf["shared_preload_libraries"].(string) != "'repmgr,timescaledb'" {
 			t.Fatal("expected preload library string to be wrapped in single quotes")
@@ -327,7 +331,7 @@ func TestValidateConfiguration(t *testing.T) {
 			"shared_preload_libraries": "",
 		}
 
-		if _, err := pgConf.ValidateConfig(valid); err == nil {
+		if _, err := pgConf.Validate(valid); err == nil {
 			t.Fatal("expected validation to fail when empty")
 		}
 
@@ -335,7 +339,7 @@ func TestValidateConfiguration(t *testing.T) {
 			"shared_preload_libraries": "timescaledb",
 		}
 
-		if _, err := pgConf.ValidateConfig(valid); err == nil {
+		if _, err := pgConf.Validate(valid); err == nil {
 			t.Fatal("expected validation to fail when repmgr is missing")
 		}
 	})
@@ -345,7 +349,7 @@ func TestValidateConfiguration(t *testing.T) {
 			"wal_level": "replica",
 		}
 
-		if _, err := pgConf.ValidateConfig(valid); err != nil {
+		if _, err := pgConf.Validate(valid); err != nil {
 			t.Fatal(err)
 		}
 
@@ -353,7 +357,7 @@ func TestValidateConfiguration(t *testing.T) {
 			"wal_level": "logical",
 		}
 
-		if _, err := pgConf.ValidateConfig(valid); err != nil {
+		if _, err := pgConf.Validate(valid); err != nil {
 			t.Fatal(err)
 		}
 
@@ -362,7 +366,7 @@ func TestValidateConfiguration(t *testing.T) {
 			"archive_mode": "off",
 		}
 
-		if _, err := pgConf.ValidateConfig(valid); err != nil {
+		if _, err := pgConf.Validate(valid); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -372,7 +376,7 @@ func TestValidateConfiguration(t *testing.T) {
 			"wal_level": "minimal",
 		}
 
-		if _, err := pgConf.ValidateConfig(valid); err == nil {
+		if _, err := pgConf.Validate(valid); err == nil {
 			t.Fatal("expected wal_level minimal to fail with archiving enabled")
 		}
 
@@ -380,7 +384,7 @@ func TestValidateConfiguration(t *testing.T) {
 			"wal_level": "logical",
 		}
 
-		if _, err := pgConf.ValidateConfig(valid); err != nil {
+		if _, err := pgConf.Validate(valid); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/internal/flypg/pg_test.go
+++ b/internal/flypg/pg_test.go
@@ -278,8 +278,9 @@ func TestValidateCompatibility(t *testing.T) {
 	}
 
 	store, _ := state.NewStore()
-	pgConf.initialize(store)
-
+	if err := pgConf.initialize(store); err != nil {
+		t.Fatal(err)
+	}
 	t.Run("SharedPreloadLibraries", func(t *testing.T) {
 		valid := ConfigMap{
 			"shared_preload_libraries": "repmgr",


### PR DESCRIPTION
Notable changes:

* Fixes formatting sensitivity surrounding `shared_preload_libraries`.
* `repmgr` extension can no longer be removed. 
* Extensions are now validated.  If the extension is not installed, we will now toss an error.
* Prevent `wal_level` from being set to `minimal` when `archive_mode` is enabled. 

Addresses: https://github.com/fly-apps/postgres-flex/issues/145 and https://github.com/fly-apps/postgres-flex/issues/155