### PR TITLE
Add missing DB size metric

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -74,6 +74,7 @@ func main() {
 		"DATA_SOURCE_PASS":                    node.SUCredentials.Password,
 		"PG_EXPORTER_EXCLUDE_DATABASE":        "template0,template1",
 		"PG_EXPORTER_AUTO_DISCOVER_DATABASES": "true",
+		"PG_EXPORTER_EXTEND_QUERY_PATH":       "/fly/queries.yaml",
 	}
 	svisor.AddProcess("exporter", "postgres_exporter --log.level=warn ",
 		supervisor.WithEnv(exporterEnv),

--- a/config/queries.yaml
+++ b/config/queries.yaml
@@ -11,7 +11,7 @@ pg_database:
         description: "Disk space used by the database"
 
 pg_replication:
-  query: "SELECT slot_name, active, pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS lag FROM pg_replication_slots;"
+  query: "SELECT slot_name, CAST(active AS TEXT), pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS lag FROM pg_replication_slots"
   master: true
   cache_seconds: 30
   metrics:
@@ -22,5 +22,5 @@ pg_replication:
       usage: "LABEL"
       description: "Whether the replication slot is active"
     - lag:
-        usage: "GAUGE"
-        description: "Replication lag in bytes"
+      usage: "GAUGE"
+      description: "Replication lag in bytes"

--- a/config/queries.yaml
+++ b/config/queries.yaml
@@ -9,3 +9,17 @@ pg_database:
     - size_bytes:
         usage: "GAUGE"
         description: "Disk space used by the database"
+
+pg_replication:
+  query: "SELECT slot_name, active, pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS lag FROM pg_replication_slots;"
+  master: true
+  metrics:
+    - slot_name:
+      usage: "LABEL"
+      description: "Name of replication slot"
+    - active:
+      usage: "LABEL"
+      description: "Whether the replication slot is active"
+    - lag:
+        usage: "GAUGE"
+        description: "Replication lag in bytes"

--- a/config/queries.yaml
+++ b/config/queries.yaml
@@ -13,6 +13,7 @@ pg_database:
 pg_replication:
   query: "SELECT slot_name, active, pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS lag FROM pg_replication_slots;"
   master: true
+  cache_seconds: 30
   metrics:
     - slot_name:
       usage: "LABEL"

--- a/config/queries.yaml
+++ b/config/queries.yaml
@@ -10,17 +10,17 @@ pg_database:
         usage: "GAUGE"
         description: "Disk space used by the database"
 
-pg_replication:
-  query: "SELECT slot_name, CAST(active AS TEXT), pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS lag FROM pg_replication_slots"
-  master: true
-  cache_seconds: 30
-  metrics:
-    - slot_name:
-      usage: "LABEL"
-      description: "Name of replication slot"
-    - active:
-      usage: "LABEL"
-      description: "Whether the replication slot is active"
-    - lag:
-      usage: "GAUGE"
-      description: "Replication lag in bytes"
+# pg_replication:
+#   query: "SELECT slot_name, CAST(active AS TEXT), pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS lag FROM pg_replication_slots"
+#   master: true
+#   cache_seconds: 30
+#   metrics:
+#     - slot_name:
+#         usage: "LABEL"
+#         description: "Name of replication slot"
+#     # - active:
+#     #     usage: "LABEL"
+#     #     description: "Whether the replication slot is active"
+#     - lag:
+#         usage: "GAUGE"
+#         description: "Replication lag in bytes"


### PR DESCRIPTION
This PR adds the missing DB size metric.

The existing PG replication query used with the Stolon implementation is not correct.  Additional work will need to go into the web dashboard before we can use the correct pg replication query.  

Partially addresses: https://github.com/fly-apps/postgres-flex/issues/154