### PR TITLE
Reduce connect timeout to 5s and reduce reconnect timeout from 60s to 30s

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -12,7 +12,7 @@ import (
 var (
 	deadMemberMonitorFrequency       = time.Hour * 1
 	replicationStateMonitorFrequency = time.Hour * 1
-	clusterStateMonitorFrequency     = time.Minute * 10
+	clusterStateMonitorFrequency     = time.Minute * 5
 
 	defaultDeadMemberRemovalThreshold   = time.Hour * 12
 	defaultInactiveSlotRemovalThreshold = time.Hour * 12

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -161,7 +161,7 @@ func (r *RepMgr) setDefaults() error {
 	conf := ConfigMap{
 		"node_id":                      nodeID,
 		"node_name":                    fmt.Sprintf("'%s'", r.PrivateIP),
-		"conninfo":                     fmt.Sprintf("'host=%s port=%d user=%s dbname=%s connect_timeout=10'", r.PrivateIP, r.Port, r.Credentials.Username, r.DatabaseName),
+		"conninfo":                     fmt.Sprintf("'host=%s port=%d user=%s dbname=%s connect_timeout=5'", r.PrivateIP, r.Port, r.Credentials.Username, r.DatabaseName),
 		"data_directory":               fmt.Sprintf("'%s'", r.DataDir),
 		"failover":                     "'automatic'",
 		"use_replication_slots":        "yes",
@@ -174,6 +174,8 @@ func (r *RepMgr) setDefaults() error {
 		"failover_validation_command":  fmt.Sprintf("'/usr/local/bin/failover_validation -visible-nodes %%v -total-nodes %%t'"),
 		"ssh_options":                  "'-o \"StrictHostKeyChecking=no\"'",
 		"priority":                     100,
+		"node_rejoin_timeout":          30,
+		"standby_reconnect_timeout":    30,
 	}
 
 	if !r.eligiblePrimary() {


### PR DESCRIPTION
This works reduces the time it takes to identify and fence a primary in the event of a network partition. 

When a network partition is initiated a couple things need to happen:

1. Repmgr will attempt to connect to a registered standby with a 5s `connect_timeout`. 
2. Repmgr will wait up to 30 seconds for the standby to reconnect before issuing a `child_node_disconnect` event. 
3. The `child_node_disconnect` event is then processed and triggers a cluster state evaluation.
4. The time it takes to evaluate the cluster will depend on the number of nodes registered with the cluster that are no longer reachable.  Worst case, we should expect 5s per registered standby.

The split-brain detection window can be calculated using the following formula:

```
connect_timeout + standby_reconnect_timeout + (registered standbys * 5)
```

For a typical 3 node cluster we are looking at:

Connect timeout: 5s
Standby reconnect timeout: 30s
Registered standbys: (2 * 5s) = 10s

Total time: 45 seconds.


There are some optimizations we can make here to cut-down on time.  E.G. We could get away evaluating only a subset of the registered members and bail once we know quorum can't be met.  I'll have to think more about this. 


 



