### PR TITLE
Bug fix: Resolve member by id rather than by ip

### DIFF
--- a/bin/restart-repmgrd
+++ b/bin/restart-repmgrd
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kill `cat /tmp/repmgrd.pid`

--- a/internal/flypg/node.go
+++ b/internal/flypg/node.go
@@ -294,7 +294,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 				)
 			}
 
-			// Re-register primary to take-on any configuration changes.
+			// Re-register primary to apply any configuration changes.
 			if err := n.RepMgr.registerPrimary(daemonRestartRequired); err != nil {
 				return fmt.Errorf("failed to re-register existing primary: %s", err)
 			}
@@ -306,7 +306,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 				}
 			}
 		case StandbyRoleName:
-			// Register existing standby to take-on any configuration changes.
+			// Register existing standby to apply any configuration changes.
 			if err := n.RepMgr.registerStandby(daemonRestartRequired); err != nil {
 				return fmt.Errorf("failed to register existing standby: %s", err)
 			}
@@ -316,7 +316,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 				return fmt.Errorf("failed to resolve primary member when updating witness: %s", err)
 			}
 
-			// Register existing witness to take-on any configuration changes.
+			// Register existing witness to apply any configuration changes.
 			if err := n.RepMgr.registerWitness(primary.Hostname); err != nil {
 				return fmt.Errorf("failed to register existing witness: %s", err)
 			}

--- a/internal/flypg/node.go
+++ b/internal/flypg/node.go
@@ -260,6 +260,10 @@ func (n *Node) PostInit(ctx context.Context) error {
 			return fmt.Errorf("failed to resolve member role: %s", err)
 		}
 
+		// Restart repmgrd in the event the IP changes for an already registered node.
+		// This can happen if the underlying volume is moved to a different node.
+		daemonRestartRequired := n.RepMgr.daemonRestartRequired(member)
+
 		switch member.Role {
 		case PrimaryRoleName:
 			// Verify cluster state to ensure we are the actual primary and not a zombie.
@@ -290,6 +294,11 @@ func (n *Node) PostInit(ctx context.Context) error {
 				)
 			}
 
+			// Re-register primary to take-on any configuration changes.
+			if err := n.RepMgr.registerPrimary(daemonRestartRequired); err != nil {
+				return fmt.Errorf("failed to re-register existing primary: %s", err)
+			}
+
 			// Readonly lock is set when disk capacity is dangerously high.
 			if !ReadOnlyLockExists() {
 				if err := BroadcastReadonlyChange(ctx, n, false); err != nil {
@@ -298,7 +307,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 			}
 		case StandbyRoleName:
 			// Register existing standby to take-on any configuration changes.
-			if err := n.RepMgr.registerStandby(); err != nil {
+			if err := n.RepMgr.registerStandby(daemonRestartRequired); err != nil {
 				return fmt.Errorf("failed to register existing standby: %s", err)
 			}
 		case WitnessRoleName:
@@ -357,7 +366,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 			}
 
 			// Register ourself as the primary
-			if err := n.RepMgr.registerPrimary(); err != nil {
+			if err := n.RepMgr.registerPrimary(false); err != nil {
 				return fmt.Errorf("failed to register repmgr primary: %s", err)
 			}
 
@@ -395,7 +404,7 @@ func (n *Node) PostInit(ctx context.Context) error {
 				}
 			} else {
 				log.Println("Registering standby")
-				if err := n.RepMgr.registerStandby(); err != nil {
+				if err := n.RepMgr.registerStandby(false); err != nil {
 					return fmt.Errorf("failed to register new standby: %s", err)
 				}
 			}

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -268,7 +268,7 @@ func (r *RepMgr) unregisterStandby(id int) error {
 	return err
 }
 
-func (r *RepMgr) restartDaemon() error {
+func (*RepMgr) restartDaemon() error {
 	_, err := utils.RunCommand("restart-repmgrd", "postgres")
 	return err
 }

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -325,13 +325,18 @@ func (*RepMgr) Members(ctx context.Context, pg *pgx.Conn) ([]Member, error) {
 }
 
 func (r *RepMgr) Member(ctx context.Context, conn *pgx.Conn) (*Member, error) {
+	id, err := r.resolveNodeID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve node id: %s", err)
+	}
+
 	members, err := r.Members(ctx, conn)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, member := range members {
-		if member.Hostname == r.PrivateIP {
+		if fmt.Sprint(member.ID) == id {
 			return &member, nil
 		}
 	}

--- a/internal/flypg/repmgr.go
+++ b/internal/flypg/repmgr.go
@@ -274,7 +274,7 @@ func (r *RepMgr) restartDaemon() error {
 }
 
 func (r *RepMgr) daemonRestartRequired(m *Member) bool {
-	return m.Hostname == r.PrivateIP
+	return m.Hostname != r.PrivateIP
 }
 
 func (r *RepMgr) unregisterWitness(id int) error {


### PR DESCRIPTION
This works to ensure that Machines can recover gracefully in the event of an IP change.  This can happen in the event we need to migrate a volume onto a different host for rebalancing purposes or because the host itself is having problems. 