### PR TITLE
Don't allow max-connections to be scaled to a point where PG can't boot

### DIFF
--- a/internal/flypg/pg.go
+++ b/internal/flypg/pg.go
@@ -397,6 +397,25 @@ func (c *PGConfig) validateCompatibility(requested ConfigMap) (ConfigMap, error)
 		}
 	}
 
+	// Max-connections
+	if v, ok := requested["max_connections"]; ok {
+		{
+			const minConnections = 10
+
+			val := v.(string)
+
+			// Convert string to int
+			maxConnections, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				return requested, fmt.Errorf("failed to parse max-connections: %s", err)
+			}
+
+			if maxConnections < minConnections {
+				return requested, fmt.Errorf("max_connections cannot be configured below %d", minConnections)
+			}
+		}
+	}
+
 	return requested, nil
 }
 

--- a/internal/flypg/pg_test.go
+++ b/internal/flypg/pg_test.go
@@ -453,6 +453,21 @@ func TestValidateCompatibility(t *testing.T) {
 		}
 	})
 
+	t.Run("maxConnections", func(t *testing.T) {
+		valid := ConfigMap{
+			"max_connections": "14",
+		}
+		if _, err := pgConf.validateCompatibility(valid); err != nil {
+			t.Fatal(err)
+		}
+
+		invalid := ConfigMap{
+			"max_connections": "4",
+		}
+		if _, err := pgConf.validateCompatibility(invalid); err == nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func stubPGConfigFile() error {


### PR DESCRIPTION
Prevents max_connections from being decreased to an unsafe value. 