### PR TITLE
Update main.go to fix scale to zero functionality

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -154,7 +154,7 @@ func scaleToZeroWorker(ctx context.Context, node *flypg.Node) error {
 				continue
 			}
 			log.Printf("Current connection count is %d\n", current)
-			if current >= 1 {
+			if current > 1 {
 				continue
 			}
 			return fmt.Errorf("scale to zero condition hit")


### PR DESCRIPTION
Currently we're checking if the number of connections is greater-or-equal to 1. However the ConnectionCount query that runs doesn't exclude itself from the result set, so it always returns at least one. 

The >= 1 check was added here: https://github.com/fly-apps/postgres-flex/pull/200. This PR reverts back to the previous `current >1 ` check.

An alternate way to fix this would be to change the query in the `getCurrentConnCount` func to use the SUCredentials instead of OperatorCredentials. This would run the query as the flypgadmin user (which is excluded from the query) instead of the Postgres user. 