### PR TITLE
FIX: Restore windows need to work off end-times

### DIFF
--- a/internal/flypg/barman_restore_test.go
+++ b/internal/flypg/barman_restore_test.go
@@ -328,8 +328,8 @@ func TestResolveBackupTarget(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	t.Run("resolve-earliest-backup-target", func(t *testing.T) {
-		backupID, err := restore.resolveBackupFromTime(list, "2024-06-25T19:44:12-00:00")
+	t.Run("resolve-oldest-target", func(t *testing.T) {
+		backupID, err := restore.resolveBackupFromTime(list, "2024-06-25T19:40:18-00:00")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -351,7 +351,7 @@ func TestResolveBackupTarget(t *testing.T) {
 	})
 
 	t.Run("resolve-backup-within-second-window", func(t *testing.T) {
-		backupID, err := restore.resolveBackupFromTime(list, "2024-06-26T17:25:15-00:00")
+		backupID, err := restore.resolveBackupFromTime(list, "2024-06-26T17:29:15-00:00")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
From the docs:
>The stop point must be after the ending time of the base backup, i.e., the end time of pg_backup_stop. You cannot use a base backup to recover to a time when that backup was in progress. (To recover to such a time, you must go back to your previous base backup and roll forward from there.)