### PR TITLE
Fixing race condition during restore process

### DIFF
--- a/internal/flypg/restore.go
+++ b/internal/flypg/restore.go
@@ -117,8 +117,6 @@ func waitForPostmasterExit(ctx context.Context) error {
 				return nil
 			case err != nil:
 				return fmt.Errorf("error checking postmaster file: %v", err)
-			default:
-				log.Println("Waiting for postmaster to exit...")
 			}
 		case <-timeout:
 			return fmt.Errorf("timed out waiting for postmaster to exit")


### PR DESCRIPTION
Sometimes the Postgres process used to reconfigure auth during restores/forks is not completely shutdown before the main PG process starts up.  This can lead to failures that won't resolve until manually rebooted. 