### PR TITLE
Add timescaledb-toolkit package

### DIFF
--- a/pg16/Dockerfile-timescaledb
+++ b/pg16/Dockerfile-timescaledb
@@ -79,6 +79,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     postgresql-$PG_MAJOR_VERSION-postgis-$POSTGIS_MAJOR \
     postgresql-$PG_MAJOR_VERSION-postgis-$POSTGIS_MAJOR-scripts \
     timescaledb-2-postgresql-$PG_MAJOR_VERSION \
+    timescaledb-toolkit-postgresql-$PG_MAJOR_VERSION \
     && apt autoremove -y && apt clean
 
 # Haproxy


### PR DESCRIPTION
Closes #264. Adds the timescaledb-toolkit package to the pg16 TimescaleDB image.

This package is already included in the pg15 image. I'm not sure if it was intentionally omitted from the pg16 image. As mentioned in #264 it looks like the toolkit has some restrictive licensing that could make it a grey area for Fly to provide, but I'm not well versed enough in legalese to say for sure.

https://github.com/timescale/timescaledb/blob/main/tsl/LICENSE-TIMESCALE
