### PR TITLE
Dependabot: auto-update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
💁 These changes configure Dependabot to automatically update the versions of any GitHub Actions that are used in existing workflows. Using this bot should prevent errors like this one in fly-apps/postgres-flex#281 and improve the maintainability of this project:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. 
Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. 
Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```