### PR TITLE
Increase waitOnRecoveryTimeout

### DIFF
--- a/internal/flypg/barman_restore.go
+++ b/internal/flypg/barman_restore.go
@@ -28,7 +28,7 @@ type BarmanRestore struct {
 
 const (
 	defaultRestoreDir     = "/data/postgresql"
-	waitOnRecoveryTimeout = 10 * time.Minute
+	waitOnRecoveryTimeout = 60 * time.Minute
 )
 
 func NewBarmanRestore(configURL string) (*BarmanRestore, error) {


### PR DESCRIPTION
Increase the waitOnRecoveryTimeout to 60 minutes for larger databases or when machines with shared CPUs are used.