### PR TITLE
Use tmpdir within /data for barman-cloud-backup/-restore

### DIFF
--- a/bin/with_tmpdir
+++ b/bin/with_tmpdir
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <TMPDIR_PATTERN> <CMD> <ARGS...>" >&2
+    exit 1
+fi
+
+TMPDIR_PATTERN=$1
+shift
+export TMPDIR=$(mktemp -d "${TMPDIR_PATTERN}")
+
+if [ -z "${TMPDIR}" ]; then
+    echo "Couldn't create temp directory, exiting" >&2
+    exit 1
+fi
+
+
+echo "Created temp directory ${TMPDIR}" >&2
+
+cleanup() {
+    local rc=$?
+
+    if [ -z "${EXITCODE}" ]; then
+        kill %% >/dev/null
+    fi
+
+    if [ -e "${TMPDIR}" ]; then
+        echo "Removing temp directory ${TMPDIR} ..."
+        rm -rf -- "${TMPDIR}"
+    fi
+
+    # restore the original exit status
+    exit ${EXITCODE:-$rc}
+}
+
+trap cleanup EXIT
+
+"$@" &
+wait %%
+EXITCODE=$?

--- a/internal/flypg/barman.go
+++ b/internal/flypg/barman.go
@@ -134,7 +134,7 @@ func (b *Barman) Backup(ctx context.Context, cfg BackupConfig) ([]byte, error) {
 		args = append(args, "-n", cfg.Name)
 	}
 
-	return utils.RunCmd(ctx, "postgres", "barman-cloud-backup", args...)
+	return utils.RunCmd(ctx, "postgres", "with_tmpdir", append([]string{"/data/barman.tmp.XXXXXXXX", "barman-cloud-backup"}, args...)...)
 }
 
 // RestoreBackup returns the command string used to restore a base backup.
@@ -149,7 +149,7 @@ func (b *Barman) RestoreBackup(ctx context.Context, name string) ([]byte, error)
 		defaultRestoreDir,
 	}
 
-	return utils.RunCmd(ctx, "postgres", "barman-cloud-restore", args...)
+	return utils.RunCmd(ctx, "postgres", "with_tmpdir", append([]string{"/data/barman.tmp.XXXXXXXX", "barman-cloud-restore"}, args...)...)
 }
 
 func (b *Barman) ListBackups(ctx context.Context) (BackupList, error) {


### PR DESCRIPTION
We are having an issue with postgres backups created by barman: they are failing, because barman creates a tar archive in `/tmp` directory, which only has ~7.5G to work with, so it runs out of space.
```
# df -h
Filesystem      Size  Used Avail Use% Mounted on
none            7.8G   48M  7.4G   1% /
/dev/vdb        7.8G   48M  7.4G   1% /.fly-upper-layer
shm             2.0G  3.1M  2.0G   1% /dev/shm
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/vdc        147G   20G  121G  14% /data
```

I've checked barman sources, and it didn't seem to have a way to configure its temp. directories, so I ended up making a wrapper script that creates a temporary directory in a place of your choice, and configured `barman-cloud-backup` and `barman-cloud-restore` commands to run through that script.

There should be a better way to handle this, but I wanted to get some early opinions on this.

Also, had to fix the haproxy configs, it seemed to complain about having two `server-template` clauses with the same name `pg`